### PR TITLE
Fixing timezone + timestamp bug in chunkedgraph module

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -515,7 +515,7 @@ class ChunkedGraphClientV1(ClientBase):
             params.update(package_timestamp(timestamp_future, name="timestamp_future"))
 
         url = self._endpoints["handle_lineage_graph"].format_map(endpoint_mapping)
-        r = handle_response(self.session.get(url, params=data))
+        r = handle_response(self.session.get(url, params=params))
 
         if as_nx_graph:
             return nx.node_link_graph(r)

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -449,11 +449,11 @@ class TestChunkedgraph:
         )
 
         qid_map = myclient.chunkedgraph.get_past_ids(
-            root_ids, timestamp_past=past_time, timestamp_future=now
+            root_ids, timestamp_past=timestamp_past, timestamp_future=now
         )
         assert qid_map == id_map
         qid_map = myclient.chunkedgraph.get_past_ids(
-            root_id_list, timestamp_past=past_time, timestamp_future=now
+            root_id_list, timestamp_past=timestamp_past, timestamp_future=now
         )
         assert qid_map == id_map
 


### PR DESCRIPTION
Parts of the module used `time.mktime` to convert datetimes into timestamps. As `time.mktime` uses the local timezone, the timestamps were influenced by ones location.