### PR TITLE
Update schemas.rst - list schema function outdated?

### DIFF
--- a/docs/guide/schemas.rst
+++ b/docs/guide/schemas.rst
@@ -15,7 +15,7 @@ we aim to have a generic set available to use.
 
 .. code:: python
 
-    client.schema.schema()
+    client.schema.get_schemas()
 
 View a specific schema
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Function seems to have been changed to get_schemas(). Current method causes error 
`AttributeError: 'SchemaClientLegacy' object has no attribute 'schema'`