### PR TITLE
BUG: Use live live query for all join queries in tables

### DIFF
--- a/caveclient/emannotationschemas.py
+++ b/caveclient/emannotationschemas.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 from .base import ClientBase, _api_endpoints, handle_response
 from .endpoints import schema_api_versions, schema_endpoints_common
 from .auth import AuthClient
+from requests import HTTPError
+import logging
+logger = logging.getLogger(__name__)
 
 server_key = "emas_server_address"
 
@@ -115,7 +118,11 @@ class SchemaClientLegacy(ClientBase):
         url = self._endpoints["schema_definition_multi"].format_map(endpoint_mapping)
         data={'schema_names': ','.join(schema_types)}
         response = self.session.post(url, params=data)
-        return handle_response(response)
+        try:
+            return handle_response(response)
+        except HTTPError:
+            logger.warning('Client requested an schema service endpoint (see "schema_definition_multi") not yet available on your deployment. Please talk to your admin about updating your deployment')
+            return None
 
     def schema_definition_all(self) -> dict[str]:
         """Get the definition of all schema_types
@@ -128,7 +135,12 @@ class SchemaClientLegacy(ClientBase):
         endpoint_mapping = self.default_url_mapping
         url = self._endpoints["schema_definition_all"].format_map(endpoint_mapping)
         response = self.session.get(url)
-        return handle_response(response)
+        try:
+            return handle_response(response)
+        except HTTPError:
+            logger.warning('Client requested an schema service endpoint (see "schema_definition_all") not yet available on your deployment. Please talk to your admin about updating your deployment')
+            return None
+
 
 
 client_mapping = {

--- a/caveclient/tools/table_manager.py
+++ b/caveclient/tools/table_manager.py
@@ -481,7 +481,7 @@ def make_kwargs_mixin(client, is_view=False, live_compatible=True):
                         metadata=metadata,
                         **self.filter_kwargs_mat,
                     )
-                else:
+                elif timestamp is None:
                     qry_table = self._reference_table
                     return client.materialize.join_query(
                         tables=self.basic_join,
@@ -494,6 +494,16 @@ def make_kwargs_mixin(client, is_view=False, live_compatible=True):
                         suffixes={self._reference_table: "_ref", self._base_table: ""},
                         metadata=metadata,
                         **self.filter_kwargs_mat,
+                    )
+                else:
+                    return self.live_query(
+                        timestamp=timestamp,
+                        offset=offset,
+                        limit=limit,
+                        split_positions=split_positions,
+                        metadata=metadata,
+                        desired_resolution=desired_resolution,
+                        allow_missing_lookups=False,
                     )
 
             def live_query(

--- a/caveclient/tools/table_manager.py
+++ b/caveclient/tools/table_manager.py
@@ -119,9 +119,8 @@ def _schema_key(schema_name, client, **kwargs):
 
 def populate_schema_cache(client, schema_definitions=None):
     if schema_definitions is None:
-        try:
-            schema_definitions = client.schema.schema_definition_all()
-        except:
+        schema_definitions = client.schema.schema_definition_all()
+        if schema_definitions is None:
             schema_definitions = {sn:None for sn in client.schema.get_schemas()}
     for schema_name, schema_definition in schema_definitions.items():
         get_col_info(schema_name, client, schema_definition=schema_definition)
@@ -251,6 +250,9 @@ def get_table_info(
         Dict mapping columns to table names
     """
     ref_table = meta.get("reference_table")
+    if ref_table is not None:
+        if len(ref_table) == 0:
+            ref_table = None
     if ref_table is None or merge_schema is False:
         schema = meta["schema"]
         ref_pts = []
@@ -463,9 +465,6 @@ def make_kwargs_mixin(client, is_view=False, live_compatible=True):
                 desired_resolution=None,
                 get_counts=False,
             ):
-                logger.warning(
-                    "The `client.materialize.tables` interface is experimental and might experience breaking changes before the feature is stabilized."
-                )
                 if self._reference_table is None:
                     qry_table = self._base_table
                     return client.materialize.query_table(
@@ -482,6 +481,9 @@ def make_kwargs_mixin(client, is_view=False, live_compatible=True):
                         **self.filter_kwargs_mat,
                     )
                 elif timestamp is None:
+                    logger.warning(
+                        "The `client.materialize.tables` interface is experimental and might experience breaking changes before the feature is stabilized."
+                    )
                     qry_table = self._reference_table
                     return client.materialize.join_query(
                         tables=self.basic_join,


### PR DESCRIPTION
client.materialize.tables.TABLE().query(timestamp=timestamp) was ignoring the timestamp value if the table was a reference table, since there is no timestamp parameter on join_query.