### PR TITLE
Protect against silent error in root IDs with `select_columns` and `timestamp`

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -146,9 +146,9 @@ def _check_select_columns_and_timestamp(select_columns, timestamp):
         has_root = False
         has_supervoxel = False
         for select_value in select_values:
-            if "_root_id" in select_value:
+            if "root_id" in select_value:
                 has_root = True
-            if "_supervoxel_id" in select_value:
+            if "supervoxel_id" in select_value:
                 has_supervoxel = True
         if has_root and not has_supervoxel:
             msg = (

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -136,12 +136,16 @@ def string_format_timestamp(ts):
         return ts
 
 
-def _check_select_columns_and_timestamp(select_columns, timestamp):
-    if timestamp is not None:
+def _check_select_columns_and_timestamp(
+    select_columns: Optional[Union[list, dict]], timestamp: Optional[datetime]
+) -> None:
+    if timestamp is not None and select_columns is not None:
         if isinstance(select_columns, list):
             select_values = select_columns
         elif isinstance(select_columns, dict):
             select_values = list(select_columns.values())
+        else:
+            return
 
         has_root = False
         has_supervoxel = False


### PR DESCRIPTION
Related to https://github.com/CAVEconnectome/MaterializationEngine/issues/134

This just raises an error client-side and instructs the user how to temporarily fix. 

In the future this will be fixed server-side, but still worth having this here in case someone is on an older version of materialization engine.