### PR TITLE
Add support for reasoning about server semantic version 

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -91,6 +91,7 @@ def _raise_for_status(r, log_warning=True):
 
 def handle_response(response, as_json=True, log_warning=True):
     """Deal with potential errors in endpoint response and return json for default case"""
+    # NOTE: consider adding "None on 404" as an option? 
     _raise_for_status(response, log_warning=log_warning)
     _check_authorization_redirect(response)
     if as_json:

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -234,16 +234,14 @@ class ClientBase(object):
 
     def _get_version(self) -> Optional[Version]:
         endpoint_mapping = self.default_url_mapping
-        url = self._endpoints["get_version"].format_map(endpoint_mapping)
+        url = self._endpoints.get("get_version", None).format_map(endpoint_mapping)
         response = self.session.get(url)
-        # TODO none_on_404 is not a thing
-        response = handle_response(response, as_json=True, none_on_404=True)
-        # if response.status_code == 404:  # server doesn't have this endpoint yet
-        #     return None
-        # else:
-        #     version_str = response.json()
-        #     version = Version(version_str)
-        #     return version
+        if response.status_code == 404:  # server doesn't have this endpoint yet
+            return None
+        else:
+            version_str = handle_response(response, as_json=True)
+            version = Version(version_str)
+            return version
 
     @property
     def server_version(self) -> Optional[Version]:

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -91,7 +91,7 @@ def _raise_for_status(r, log_warning=True):
 
 def handle_response(response, as_json=True, log_warning=True):
     """Deal with potential errors in endpoint response and return json for default case"""
-    # NOTE: consider adding "None on 404" as an option? 
+    # NOTE: consider adding "None on 404" as an option?
     _raise_for_status(response, log_warning=log_warning)
     _check_authorization_redirect(response)
     if as_json:

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -337,18 +337,18 @@ def _version_fails_constraint(version: Version, constraint: str = None):
 
 
 @parametrized
-def check_version_compatibility(
+def _check_version_compatibility(
     method: Callable, method_constraint: str = None, kwarg_use_constraints: dict = None
 ) -> Callable:
     """
-    This decorator is used to check the compatibility features in the client and
+    This decorator is used to check the compatibility of features in the client and
     server versions. If the server version is not compatible with the constraint, an
     error will be raised.
 
     Parameters
     ----------
     method
-        Method to be decorated.
+        Method of the client to be decorated.
     method_constraint
         Version constraint for the method, described as a comparison operator
         followed by the version number. For example, "<=1.0.0" would indicate that this

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -5,7 +5,7 @@ import textwrap
 import urllib
 import webbrowser
 from functools import wraps
-from typing import Callable
+from typing import Callable, Optional
 
 import numpy as np
 import pandas as pd
@@ -231,6 +231,24 @@ class ClientBase(object):
     @property
     def api_version(self):
         return self._api_version
+
+    def _get_version(self) -> Optional[Version]:
+        endpoint_mapping = self.default_url_mapping
+        url = self._endpoints["get_version"].format_map(endpoint_mapping)
+        response = self.session.get(url)
+        # TODO none_on_404 is not a thing
+        response = handle_response(response, as_json=True, none_on_404=True)
+        # if response.status_code == 404:  # server doesn't have this endpoint yet
+        #     return None
+        # else:
+        #     version_str = response.json()
+        #     version = Version(version_str)
+        #     return version
+
+    @property
+    def server_version(self) -> Optional[Version]:
+        """The version of the remote server."""
+        return self._server_version
 
     @staticmethod
     def raise_for_status(r, log_warning=True):

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -3,14 +3,13 @@
 import datetime
 import json
 import logging
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Tuple, Union
 from urllib.parse import urlencode
 
 import networkx as nx
 import numpy as np
 import pandas as pd
 import pytz
-from packaging.version import Version
 
 from .auth import AuthClient
 from .base import (
@@ -199,8 +198,6 @@ class ChunkedGraphClientV1(ClientBase):
     @property
     def table_name(self):
         return self._table_name
-
-    
 
     def _process_timestamp(self, timestamp):
         """Process timestamp with default logic"""

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -200,34 +200,7 @@ class ChunkedGraphClientV1(ClientBase):
     def table_name(self):
         return self._table_name
 
-    # TODO refactor to base client
-    def _get_version(self) -> Optional[Version]:
-        endpoint_mapping = self.default_url_mapping
-        url = self._endpoints["get_version"].format_map(endpoint_mapping)
-        response = self.session.get(url)
-        if response.status_code == 404:  # server doesn't have this endpoint yet
-            return None
-        else:
-            version_str = response.json()
-            version = Version(version_str)
-            return version
-
-    @property
-    def server_version(self) -> Optional[Version]:
-        """The version of the remote server."""
-        return self._server_version
-
-    @property
-    def max_server_version(self) -> Version:
-        """
-        The version of the remote server, or the last version of the server which
-        does not have the endpoint for displaying its version if unavailable.
-        """
-        if self._server_version is None:
-            # this is the last version that doesn't have the endpoints
-            return Version("2.15.0")
-        else:
-            return self._server_version
+    
 
     def _process_timestamp(self, timestamp):
         """Process timestamp with default logic"""

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -190,7 +190,7 @@ class ChunkedGraphClientV1(ClientBase):
         self._default_timestamp = timestamp
         self._table_name = table_name
         self._segmentation_info = None
-        self._server_version = self._get_server_version()
+        self._server_version = self._get_version()
 
     @property
     def default_url_mapping(self):
@@ -201,27 +201,28 @@ class ChunkedGraphClientV1(ClientBase):
         return self._table_name
 
     # TODO refactor to base client
-    def _get_server_version(self) -> Optional[Version]:
+    def _get_version(self) -> Optional[Version]:
         endpoint_mapping = self.default_url_mapping
-        url = self._endpoints["get_current_semver"].format_map(endpoint_mapping)
+        url = self._endpoints["get_version"].format_map(endpoint_mapping)
         response = self.session.get(url)
-        print(url)
         if response.status_code == 404:  # server doesn't have this endpoint yet
             return None
         else:
             version_str = response.json()
-            print(response.json())
-            print(response)
             version = Version(version_str)
             return version
 
     @property
     def server_version(self) -> Optional[Version]:
+        """The version of the remote server."""
         return self._server_version
 
     @property
     def max_server_version(self) -> Version:
-        """Old versions of the server will not even have the endpoint to know"""
+        """
+        The version of the remote server, or the last version of the server which 
+        does not have the endpoint for displaying its version if unavailable.
+        """
         if self._server_version is None:
             # this is the last version that doesn't have the endpoints
             return Version("2.15.0")

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -13,7 +13,13 @@ import pytz
 import pandas as pd
 
 from .auth import AuthClient
-from .base import BaseEncoder, ClientBase, _api_endpoints, handle_response
+from .base import (
+    BaseEncoder,
+    ClientBase,
+    _api_endpoints,
+    check_version_compatibility,
+    handle_response,
+)
 from .endpoints import (
     chunkedgraph_api_versions,
     chunkedgraph_endpoints_common,
@@ -819,6 +825,7 @@ class ChunkedGraphClientV1(ClientBase):
         rd = handle_response(response)
         return np.int64(rd["nodes"]), np.double(rd["affinities"]), np.int32(rd["areas"])
 
+    @check_version_compatibility(kwarg_use_constraints={"bounds": ">=2.15.0"})
     def level2_chunk_graph(self, root_id, bounds=None) -> list:
         """
         Get graph of level 2 chunks, the smallest agglomeration level above supervoxels.

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -17,7 +17,7 @@ from .base import (
     BaseEncoder,
     ClientBase,
     _api_endpoints,
-    check_version_compatibility,
+    _check_version_compatibility,
     handle_response,
 )
 from .endpoints import (
@@ -205,10 +205,13 @@ class ChunkedGraphClientV1(ClientBase):
         endpoint_mapping = self.default_url_mapping
         url = self._endpoints["get_current_semver"].format_map(endpoint_mapping)
         response = self.session.get(url)
+        print(url)
         if response.status_code == 404:  # server doesn't have this endpoint yet
             return None
         else:
             version_str = response.json()
+            print(response.json())
+            print(response)
             version = Version(version_str)
             return version
 
@@ -808,9 +811,7 @@ class ChunkedGraphClientV1(ClientBase):
         rd = handle_response(response)
         return np.int64(rd["nodes"]), np.double(rd["affinities"]), np.int32(rd["areas"])
 
-    @check_version_compatibility(
-        method_constraint=">=1.0.0", kwarg_use_constraints={"bounds": ">=2.15.0"}
-    )
+    @_check_version_compatibility(kwarg_use_constraints={"bounds": ">=2.15.0"})
     def level2_chunk_graph(self, root_id, bounds=None) -> list:
         """
         Get graph of level 2 chunks, the smallest agglomeration level above supervoxels.
@@ -847,6 +848,8 @@ class ChunkedGraphClientV1(ClientBase):
 
         r = handle_response(response)
 
+        # TODO in theory, could remove this check if we are confident in the server
+        # version fix
         used_bounds = response.headers.get("Used-Bounds")
         used_bounds = used_bounds == "true" or used_bounds == "True"
         if bounds is not None and not used_bounds:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -220,7 +220,7 @@ class ChunkedGraphClientV1(ClientBase):
     @property
     def max_server_version(self) -> Version:
         """
-        The version of the remote server, or the last version of the server which 
+        The version of the remote server, or the last version of the server which
         does not have the endpoint for displaying its version if unavailable.
         """
         if self._server_version is None:

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -128,6 +128,7 @@ infoservice_api_versions = {1: infoservice_endpoints_v1, 2: infoservice_endpoint
 pcg_common = "{cg_server_address}/segmentation"
 chunkedgraph_endpoints_common = {
     "get_api_versions": pcg_common + "/api/versions",
+    "get_current_semver": pcg_common + "/api/current_semver",
     "info": pcg_common + "/table/{table_id}/info",
 }
 

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -128,7 +128,7 @@ infoservice_api_versions = {1: infoservice_endpoints_v1, 2: infoservice_endpoint
 pcg_common = "{cg_server_address}/segmentation"
 chunkedgraph_endpoints_common = {
     "get_api_versions": pcg_common + "/api/versions",
-    "get_current_semver": pcg_common + "/api/current_semver",
+    "get_version": pcg_common + "/api/version",
     "info": pcg_common + "/table/{table_id}/info",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,17 @@ with open("requirements.txt", "r") as f:
 
 # read the contents of README file
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.rst").read_text()
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     version=find_version("caveclient", "__init__.py"),
     name="caveclient",
-    description="a service for interacting with the Connectome Annotation Versioning Engine",
+    description="A client for interacting with the Connectome Annotation Versioning Engine",
     long_description=long_description,
-    long_description_content_type="text/x-rst",
+    long_description_content_type="text/markdown",
     author="Forrest Collman, Casey Schneider-Mizell, Sven Dorkenwald",
     author_email="forrestc@alleninstute.org,caseys@alleninstitute.org,svenmd@princeton.edu,",
-    url="https://github.com/seung-lab/CAVEclient",
+    url="https://github.com/CAVEconnectome/CAVEclient",
     packages=find_packages(where="."),
     include_package_data=True,
     install_requires=required,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,18 +27,46 @@ test_info = {
     "viewer_resolution_y": 4.0,
     "viewer_resolution_z": 40,
 }
+url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
+mapping = {"i_server_address": TEST_GLOBAL_SERVER, "datastack_name": TEST_DATASTACK}
+url = url_template.format_map(mapping)
 
 
 @pytest.fixture()
 @responses.activate
 def myclient():
-    url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
-    mapping = {"i_server_address": TEST_GLOBAL_SERVER, "datastack_name": TEST_DATASTACK}
-    url = url_template.format_map(mapping)
-
     responses.add(responses.GET, url, json=test_info, status=200)
 
     client = CAVEclient(
         TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
     )
+
+    # need to mock the response of the version checking code for each sub-client which
+    # wants that information, and then create the sub-client here since the mock is
+    # narrowly scoped to this function
+    version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/version"
+    responses.add(responses.GET, version_url, json="2.15.0", status=200)
+
+    client.chunkedgraph  # this will trigger the version check
+
+    return client
+
+
+@pytest.fixture()
+@responses.activate
+def old_chunkedgraph_client():
+    responses.add(responses.GET, url, json=test_info, status=200)
+
+    client = CAVEclient(
+        TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
+    )
+
+    # need to mock the response of the version checking code for each sub-client which
+    # wants that information, and then create the sub-client here since the mock is
+    # narrowly scoped to this function
+    version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/version"
+    responses.add(responses.GET, version_url, json="1.0.0", status=200)
+
+    client.chunkedgraph  # this will trigger the version check
+
     return client

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 from urllib.parse import urlencode
 
 import numpy as np
@@ -15,6 +16,31 @@ from caveclient.endpoints import (
 )
 
 from .conftest import TEST_LOCAL_SERVER, test_info
+
+TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
+TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
+TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
+
+test_info = {
+    "viewer_site": "http://neuromancer-seung-import.appspot.com/",
+    "aligned_volume": {
+        "name": "test_volume",
+        "image_source": f"precomputed://https://{TEST_LOCAL_SERVER}/test-em/v1",
+        "id": 1,
+        "description": "This is a test only dataset.",
+    },
+    "synapse_table": "test_synapse_table",
+    "description": "This is the first test datastack. ",
+    "local_server": TEST_LOCAL_SERVER,
+    "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
+    "soma_table": "test_soma",
+    "analysis_database": None,
+    "viewer_resolution_x": 4.0,
+    "viewer_resolution_y": 4.0,
+    "viewer_resolution_z": 40,
+}
+# version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/current_semver"
+# responses.add(responses.GET, version_url, json="1.0.0", status=200)
 
 
 def binary_body_match(body):
@@ -421,11 +447,13 @@ class TestChunkedgraph:
                 root_id, bounds=bounds
             )
 
-    def test_lvl2subgraph_old_server_fails_bounds(self, myclient):
-        myclient.chunkedgraph._version = "0.1.0"
+    @responses.activate
+    def test_lvl2subgraph_old_server_fails_bounds(self, old_chunkedgraph_client):
+        bounds = np.array([[83875, 85125], [82429, 83679], [20634, 20884]])
+        root_id = 864691136812623475
         with pytest.raises(ServerIncompatibilityError):
-            myclient.chunkedgraph.level2_chunk_graph(
-                0, bounds=np.array([[0, 1], [0, 1], [0, 1]])
+            old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(
+                root_id, bounds=bounds
             )
 
     @responses.activate

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 from urllib.parse import urlencode
 
 import numpy as np
@@ -16,31 +15,6 @@ from caveclient.endpoints import (
 )
 
 from .conftest import TEST_LOCAL_SERVER, test_info
-
-TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
-TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
-TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
-
-test_info = {
-    "viewer_site": "http://neuromancer-seung-import.appspot.com/",
-    "aligned_volume": {
-        "name": "test_volume",
-        "image_source": f"precomputed://https://{TEST_LOCAL_SERVER}/test-em/v1",
-        "id": 1,
-        "description": "This is a test only dataset.",
-    },
-    "synapse_table": "test_synapse_table",
-    "description": "This is the first test datastack. ",
-    "local_server": TEST_LOCAL_SERVER,
-    "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
-    "soma_table": "test_soma",
-    "analysis_database": None,
-    "viewer_resolution_x": 4.0,
-    "viewer_resolution_y": 4.0,
-    "viewer_resolution_z": 40,
-}
-# version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/current_semver"
-# responses.add(responses.GET, version_url, json="1.0.0", status=200)
 
 
 def binary_body_match(body):

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -8,6 +8,7 @@ import pytz
 import responses
 from responses.matchers import json_params_matcher
 
+from caveclient.base import ServerIncompatibilityError
 from caveclient.endpoints import (
     chunkedgraph_endpoints_common,
     chunkedgraph_endpoints_v1,
@@ -418,6 +419,13 @@ class TestChunkedgraph:
         with pytest.raises(ValueError):
             qlvl2_graph = myclient.chunkedgraph.level2_chunk_graph(
                 root_id, bounds=bounds
+            )
+
+    def test_lvl2subgraph_old_server_fails_bounds(self, myclient):
+        myclient.chunkedgraph._version = "0.1.0"
+        with pytest.raises(ServerIncompatibilityError):
+            myclient.chunkedgraph.level2_chunk_graph(
+                0, bounds=np.array([[0, 1], [0, 1], [0, 1]])
             )
 
     @responses.activate


### PR DESCRIPTION
Note: Currently, this is just for the chunkedgraph, but could easily be extended to the other services if we like the pattern

## This PR adds
- Adds logic for talking to an endpoint which just returns the full semver for the service
   - Happens on sub-client creation
- Stores this info as a `Version` object, which allows for easy operations like checking `>`,`>=` etc.
- Adds a decorator for convenience, which allows specification that a method or its keyword arguments are only valid for specific constraints of server version
   - Opted not to do that for arguments, could discuss further but since those are required that felt like it didn't fit the pattern
- As an example, applies this decorator to a recent addition to the level2_chunk_graph `bounds` argument

## This PR does not add
A few things we discussed but I think are separate PRs 
- In theory, this kind of reasoning about the server version might allow for consolidating the multiple API version clients into one for each service, with method-level logic about dispatching to particular sub-functions depending on the version
- There are some use cases that don't fall under the decorator that are more adhoc, for instance, the recent bug where using timestamp and select columns can be unsafe. I think those will need to be done on a case by case basis, but could at least use some of the tools here

## Worth discussing
- [ ] How to generalize testing with this kind of thing (since mocking needs to happen @ client level)
- [ ] How to handle case for servers that don't have this endpoint yet (I have some ideas here but it gets ugly)
   - [ ] How to refactor to use `handle_response` but be OK with a 404 error