### PR TITLE
removing pyarrow pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pyarrow>=3,<12
+pyarrow>=3
 requests
 urllib3
 pandas


### PR DESCRIPTION
python 3.12 installation fails with no c compiler setup because older versions of pyarrow are not available as pre-built wheels.