### PR TITLE
BUG: ignore kwarg=None in constrained calls

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -409,7 +409,7 @@ def _check_version_compatibility(
                 )
 
                 raise ServerIncompatibilityError(msg)
-            
+
         if kwarg_use_constraints is not None:
             # this protects against someone passing in a positional argument for the
             # kwarg we are guarding

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -370,6 +370,10 @@ def _check_version_compatibility(
     server versions. If the server version is not compatible with the constraint, an
     error will be raised.
 
+    Note that methods being decorated must use keyword-only arguments for the keywords
+    that are being checked for compatibility. The decorator also assumes that the first
+    argument of the method is the client instance (self).
+
     Parameters
     ----------
     method

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -419,7 +419,6 @@ def _check_version_compatibility(
 
             for kwarg, kwarg_constraint in kwarg_use_constraints.items():
                 if check_kwargs.get(kwarg, None) is None:
-                    print(check_kwargs)
                     continue
                 elif _version_fails_constraint(self.server_version, kwarg_constraint):
                     msg = (

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -370,9 +370,7 @@ def _check_version_compatibility(
     server versions. If the server version is not compatible with the constraint, an
     error will be raised.
 
-    Note that methods being decorated must use keyword-only arguments for the keywords
-    that are being checked for compatibility. The decorator also assumes that the first
-    argument of the method is the client instance (self).
+    The decorator assumes that the first argument of the method is the client instance (self).
 
     Parameters
     ----------
@@ -412,9 +410,12 @@ def _check_version_compatibility(
 
                 raise ServerIncompatibilityError(msg)
         if kwarg_use_constraints is not None:
+            # this protects against someone passing in a positional argument for the 
+            # kwarg we are guarding
+            kwargs.update(zip(method.__code__.co_varnames[1:], args))
             for kwarg, kwarg_constraint in kwarg_use_constraints.items():
                 if kwargs.get(kwarg, None) is None:
-                    # Constaint kwarg is either not set or is None.
+                    # Constraint kwarg is either not set or is None.
                     continue
                 elif _version_fails_constraint(self.server_version, kwarg_constraint):
                     msg = (

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -409,7 +409,10 @@ def _check_version_compatibility(
                 raise ServerIncompatibilityError(msg)
         if kwarg_use_constraints is not None:
             for kwarg, kwarg_constraint in kwarg_use_constraints.items():
-                if _version_fails_constraint(self.server_version, kwarg_constraint):
+                if kwargs.get(kwarg, None) is None:
+                    # Constaint kwarg is either not set or is None.
+                    continue
+                elif _version_fails_constraint(self.server_version, kwarg_constraint):
                     msg = (
                         f"Use of keyword argument `{kwarg}` in `{method.__name__}` "
                         "is only permitted "

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -409,13 +409,17 @@ def _check_version_compatibility(
                 )
 
                 raise ServerIncompatibilityError(msg)
+            
         if kwarg_use_constraints is not None:
-            # this protects against someone passing in a positional argument for the 
+            # this protects against someone passing in a positional argument for the
             # kwarg we are guarding
-            kwargs.update(zip(method.__code__.co_varnames[1:], args))
+            check_kwargs = kwargs.copy()
+            # add in any positional arguments that are not self to the checking
+            check_kwargs.update(zip(method.__code__.co_varnames[1:], args[1:]))
+
             for kwarg, kwarg_constraint in kwarg_use_constraints.items():
-                if kwargs.get(kwarg, None) is None:
-                    # Constraint kwarg is either not set or is None.
+                if check_kwargs.get(kwarg, None) is None:
+                    print(check_kwargs)
                     continue
                 elif _version_fails_constraint(self.server_version, kwarg_constraint):
                     msg = (

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -782,7 +782,7 @@ class ChunkedGraphClientV1(ClientBase):
         return np.int64(rd["nodes"]), np.double(rd["affinities"]), np.int32(rd["areas"])
 
     @_check_version_compatibility(kwarg_use_constraints={"bounds": ">=2.15.0"})
-    def level2_chunk_graph(self, root_id, bounds=None) -> list:
+    def level2_chunk_graph(self, root_id, *, bounds=None) -> list:
         """
         Get graph of level 2 chunks, the smallest agglomeration level above supervoxels.
 

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -782,7 +782,7 @@ class ChunkedGraphClientV1(ClientBase):
         return np.int64(rd["nodes"]), np.double(rd["affinities"]), np.int32(rd["areas"])
 
     @_check_version_compatibility(kwarg_use_constraints={"bounds": ">=2.15.0"})
-    def level2_chunk_graph(self, root_id, *, bounds=None) -> list:
+    def level2_chunk_graph(self, root_id, bounds=None) -> list:
         """
         Get graph of level 2 chunks, the smallest agglomeration level above supervoxels.
 

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -430,9 +430,20 @@ class TestChunkedgraph:
                 root_id, bounds=bounds
             )
         with pytest.raises(ServerIncompatibilityError):
-            old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(
-                root_id, bounds
-            )
+            old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(root_id, bounds)
+
+        # should not fail even on old server when bounds are default value
+        # mock a response
+        endpoint_mapping = self._default_endpoint_map
+        endpoint_mapping["root_id"] = root_id
+        url = chunkedgraph_endpoints_v1["lvl2_graph"].format_map(endpoint_mapping)
+        responses.add(
+            responses.GET,
+            json={"edge_graph": []},
+            url=url,
+            headers={"Used-Bounds": "True"},
+        )
+        old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(root_id, bounds=None)
 
     @responses.activate
     def test_get_remeshing(self, myclient):

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -429,6 +429,10 @@ class TestChunkedgraph:
             old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(
                 root_id, bounds=bounds
             )
+        with pytest.raises(ServerIncompatibilityError):
+            old_chunkedgraph_client.chunkedgraph.level2_chunk_graph(
+                root_id, bounds
+            )
 
     @responses.activate
     def test_get_remeshing(self, myclient):


### PR DESCRIPTION
The new kwargs constraint throws an error if keyword cannot be used with the server version, but does not check if keyword is actually defined as anything. This checks if the kwarg is None before throwing the error to ignore null cases.

Closes #178 

- Clarifies that decorator should be used for keyword-only arguments
- Adds keyword only to level2_chunk_graph (technically a breaking change) 