### PR TITLE
use JSONencoder to reformat metadata to simple objects

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -24,9 +24,7 @@ class BaseEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, set):
             return list(obj)
-        if isinstance(obj, np.uint64):
-            return int(obj)
-        if isinstance(obj, np.int64):
+        if isinstance(obj, np.integer):
             return int(obj)
         if isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -1881,7 +1881,7 @@ class MaterializationClientV2(ClientBase):
                 attrs["dataframe_resolution"] = desired_resolution
 
         attrs.update(kwargs)
-        return attrs
+        return json.loads(json.dumps(attrs, cls=BaseEncoder))
 
 
 class MaterializationClientV3(MaterializationClientV2):


### PR DESCRIPTION
Before adding metadata attributes to the returned data frame, pass through JSON encode/decode to convert arrays, pandas series, etc into simple objects like lists. This will more robustly fix issues with df.attrs than before.