### PR TITLE
Require non-null datastack for using datastack to server address map

### DIFF
--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -188,7 +188,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
 
         return handle_response(response)
 
-    def get_new_token(self, open=False):
+    def get_new_token(self, open=False, no_text=False):
         """Currently, returns instructions for getting a new token based on the current settings and saving it to the local environment. New OAuth tokens are currently not able to be retrieved programmatically.
 
         Parameters
@@ -207,7 +207,8 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
                 3b) Set it for the current session only with client.auth.token = "PASTE_YOUR_TOKEN_HERE"
                 Note: If you need to save or load multiple tokens, please read the documentation for details.
                 Warning! Creating a new token by finishing step 2 will invalidate the previous token!"""
-        print(txt)
+        if not no_text:
+            print(txt)
         if open:
             webbrowser.open(auth_url)
         return None

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -56,7 +56,7 @@ def write_map(data, filename=None):
 
 def handle_server_address(datastack, server_address, filename=None, write=False):
     data = read_map(filename)
-    if server_address is not None:
+    if server_address is not None and datastack is not None:
         if write and server_address != data.get(datastack):
             data[datastack] = server_address
             wrote = write_map(data, filename)


### PR DESCRIPTION
Add datastack check to not record datastack-to-server mapping if datastack is None.