### PR TITLE
Framework- and sub-client version and timestamp setting 

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import logging
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 import networkx as nx
@@ -198,6 +198,18 @@ class ChunkedGraphClientV1(ClientBase):
     def table_name(self):
         return self._table_name
 
+    @property
+    def timestamp(self) -> Optional[datetime.datetime]:
+        """Default timestamp to use in queries that accept a `timestamp` argument.
+        If None, equivalent to querying the current state of the chunkedgraph."""
+        return self._default_timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp: Optional[datetime.datetime]):
+        if (timestamp is not None) and (not isinstance(timestamp, datetime.datetime)):
+            raise ValueError("Timestamp must be a datetime.datetime object")
+        self._default_timestamp = timestamp
+
     def _process_timestamp(self, timestamp):
         """Process timestamp with default logic"""
         if timestamp is None:
@@ -217,7 +229,8 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel IDs to look up.
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the current time.
+            default None. If None, uses the `timestamp` property for this client, which 
+            defaults to the current time.
         stop_layer : int or None, optional
             If True, looks up IDs only up to a given stop layer. Default is None.
 
@@ -246,7 +259,8 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel id value
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the current time.
+            default None. If None, uses the `timestamp` property for this client, which 
+            defaults to the current time.
 
         Returns
         -------

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -201,12 +201,20 @@ class ChunkedGraphClientV1(ClientBase):
     @property
     def timestamp(self) -> Optional[datetime.datetime]:
         """Default timestamp to use in queries that accept a `timestamp` argument.
-        If None, equivalent to querying the current state of the chunkedgraph."""
+        If None, equivalent to querying the current state of the chunkedgraph. If this
+        ChunkedgraphClient has a parent CAVEclient, then this timestamp can only be
+        modified at the CAVEclient level."""
         return self._default_timestamp
 
     @timestamp.setter
-    def timestamp(self, timestamp: Optional[datetime.datetime]):
-        if (timestamp is not None) and (not isinstance(timestamp, datetime.datetime)):
+    def timestamp(self, timestamp: datetime.datetime):
+        if self.fc is not None:
+            msg = (
+                "Cannot modify timestamp on a ChunkedGraphClient with a parent "
+                "CAVEclient"
+            )
+            raise ValueError(msg)
+        if not isinstance(timestamp, datetime.datetime):
             raise ValueError("Timestamp must be a datetime.datetime object")
         self._default_timestamp = timestamp
 
@@ -1254,7 +1262,8 @@ class ChunkedGraphClientV1(ClientBase):
             Defaults to None (assumes now).
         end_timestamp : datetime.datetime, optional
             Timestamp to check whether these IDs were valid before this timestamp.
-            Defaults to None (assumes now).
+            If None, uses the `timestamp` property for this client, which
+            defaults to the current time.
 
         Returns
         -------

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -229,7 +229,7 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel IDs to look up.
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the `timestamp` property for this client, which 
+            default None. If None, uses the `timestamp` property for this client, which
             defaults to the current time.
         stop_layer : int or None, optional
             If True, looks up IDs only up to a given stop layer. Default is None.
@@ -259,7 +259,7 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel id value
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the `timestamp` property for this client, which 
+            default None. If None, uses the `timestamp` property for this client, which
             defaults to the current time.
 
         Returns
@@ -1028,8 +1028,8 @@ class ChunkedGraphClientV1(ClientBase):
         root_id : int
             Object root ID.
         timestamp : datetime.datetime or None, optional
-            Timestamp of where to query IDs from. If None then will assume you want
-            till now.
+            Timestamp of where to query IDs from. If None, uses the `timestamp` property
+            for this client, which defaults to the current time.
         timestamp_future : datetime.datetime or None, optional
             DEPRECATED name, use `timestamp` instead.
             Timestamp to suggest IDs from (note can be in the past relative to the
@@ -1047,9 +1047,9 @@ class ChunkedGraphClientV1(ClientBase):
             logger.warning("timestamp_future is deprecated, use timestamp instead")
             timestamp = timestamp_future
 
-        if timestamp is None:
-            timestamp = datetime.datetime.now(datetime.timezone.utc)
-        elif timestamp.tzinfo is None:
+        timestamp = self._process_timestamp(timestamp)
+
+        if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
 
         # or if timestamp_root is less than timestamp_future
@@ -1119,7 +1119,8 @@ class ChunkedGraphClientV1(ClientBase):
             Root IDs to check.
         timestamp : datetime.datetime, optional
             Timestamp to check whether these IDs are valid root IDs in the chunked
-            graph. Defaults to None (assumes now).
+            graph. If None, uses the `timestamp` property for this client, which
+            defaults to the current time.
 
         Returns
         -------
@@ -1165,8 +1166,9 @@ class ChunkedGraphClientV1(ClientBase):
         root_id : int
             Root ID of the potentially outdated object.
         timestamp : datetime, optional
-            Datetime at which "latest" roots are being computed, by default None. If
-            None, the current time is used. Note that this has to be a timestamp after
+            Datetime at which "latest" roots are being computed, by default None.
+            If None, uses the `timestamp` property for this client, which
+            defaults to the current time. Note that this has to be a timestamp after
             the creation of the `root_id`.
         stop_layer : int, optional
             Chunk level at which to compute overlap, by default None.

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -113,10 +113,9 @@ def concatenate_position_columns(df, inplace=False):
     return df2
 
 
-def convert_timestamp(ts: datetime):
+def convert_timestamp(ts: Optional[Union[datetime, float]]):
     if ts == "now":
         ts = datetime.now(timezone.utc)
-
     if isinstance(ts, datetime):
         if ts.tzinfo is None:
             return pytz.UTC.localize(dt=ts)
@@ -299,7 +298,7 @@ class MaterializationClientV2(ClientBase):
     def timestamp(self) -> Optional[datetime]:
         """Default timestamp to use in queries that accept a `timestamp` argument.
         If None, equivalent to querying the most recent materialization. If this
-        MaterializationClient has a parent CAVEclient, then this timestamp can only be 
+        MaterializationClient has a parent CAVEclient, then this timestamp can only be
         modified at the CAVEclient level."""
         return self._timestamp
 
@@ -733,7 +732,7 @@ class MaterializationClientV2(ClientBase):
             Version to query, by default None.
             If None, defaults to one specified in client.
         timestamp : datetime.datetime, optional
-            Timestamp to query, by default None. If passsed will do a live query.
+            Timestamp to query, by default None. If passed will do a live query.
             Error if also passing a materialization version
         metadata : bool, optional
             Toggle to return metadata (default True), by default True. If True


### PR DESCRIPTION
Draft PR (mainly intended to spur discussion of what this should look like)

- Closes https://github.com/CAVEconnectome/CAVEclient/issues/191 (adds a property for the timestamp with a setter/getter) but now larger in scope than #193 
- Adds documentation about the behavior with the default timestamp (previously it said this was always now, which wasn't necessarily true if someone made a chunkedgraph client with a timestamp)
- Makes it so that get_latest_roots respects the default timestamp - this is a change in logic but I think it makes sense