### PR TITLE
Get root timestamps update

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -5,7 +5,7 @@ import textwrap
 import urllib
 import webbrowser
 from functools import wraps
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -348,7 +348,9 @@ class ServerIncompatibilityError(Exception):
         super().__init__(message)
 
 
-def _version_fails_constraint(version: Version, constraint: str | Iterable[str] = None):
+def _version_fails_constraint(
+    version: Version, constraint: Optional[Union[str, Iterable[str]]] = None
+):
     """Check if a version fails a constraint
 
     Parameters

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -5,7 +5,7 @@ import textwrap
 import urllib
 import webbrowser
 from functools import wraps
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 
 import numpy as np
 import pandas as pd
@@ -348,15 +348,41 @@ class ServerIncompatibilityError(Exception):
         super().__init__(message)
 
 
-def _version_fails_constraint(version: Version, constraint: str = None):
+def _version_fails_constraint(version: Version, constraint: str | Iterable[str] = None):
+    """Check if a version fails a constraint
+
+    Parameters
+    ----------
+    version : Version
+        The version to check
+    constraint : str | Iterable[str]
+        The constraint to check against. Can be a single string or a list of strings.
+        If a list of constraints will return False as long there is at least one contraint
+        that it meets.
+
+        Note: if you want to have an AND constraint you can pass in a complex string, i.e. "<=1.0.0,>0.5.0"
+        either as a single string or one in the list.
+
+    Returns
+    -------
+    bool
+        True if the version fails the constraint(s), False otherwise.
+    """
     if constraint is None:
         return False
     else:
         if version is None:
             return True
         else:
-            specifier = SpecifierSet(constraint)
-            return version not in specifier
+            if isinstance(constraint, str):
+                specifier = SpecifierSet(constraint)
+                return version not in specifier
+            else:
+                specifiers = []
+                for c in constraint:
+                    specifiers.append(SpecifierSet(c))
+                # if any of the constraints are met, return False
+                return all(version not in s for s in specifiers)
 
 
 @parametrized
@@ -386,6 +412,9 @@ def _check_version_compatibility(
         less than or equal to 1.0.0. An error will be raised only if the user both
         provides the keyword argument (even if passing in the default value!) and the
         server version is not compatible with the constraint.
+
+        note you can also pass in a list of constraints to check against,
+        if any of the constraints are met.
 
     Raises
     ------

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1280,9 +1280,12 @@ class ChunkedGraphClientV1(ClientBase):
 
         return np.isin(node_ids, valid_ids)
 
-    @_check_version_compatibility(kwarg_use_constraints={"latest": ">=2.17.0", "timestamp": ">=2.17.0})
-    def get_root_timestamps(self, root_ids, latest: bool = False,
-                            timestamp: datetime.datetime = None) -> np.ndarray:
+    @_check_version_compatibility(
+        kwarg_use_constraints={"latest": ">=2.17.0", "timestamp": ">=2.17.0"}
+    )
+    def get_root_timestamps(
+        self, root_ids, latest: bool = False, timestamp: datetime.datetime = None
+    ) -> np.ndarray:
         """Retrieves timestamps when roots where created.
 
         Parameters
@@ -1297,7 +1300,7 @@ class ChunkedGraphClientV1(ClientBase):
             if you don't specify a timestamp parameter.
         timestamp: datetime.datetime, optional
             Timestamp to query when using latest=True. Use this to provide consistent results for a particular
-            timestamp.If an ID is still valid at a point in the future past this timestamp, the query will still 
+            timestamp.If an ID is still valid at a point in the future past this timestamp, the query will still
             return this timestamp as the latest moment in time. An error will occur if you provide a timestamp
             for which the root ID is not valid.
 

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1280,13 +1280,28 @@ class ChunkedGraphClientV1(ClientBase):
 
         return np.isin(node_ids, valid_ids)
 
-    def get_root_timestamps(self, root_ids) -> np.ndarray:
+    @_check_version_compatibility(kwarg_use_constraints={"latest": ">=2.17.0", "timestamp": ">=2.17.0})
+    def get_root_timestamps(self, root_ids, latest: bool = False,
+                            timestamp: datetime.datetime = None) -> np.ndarray:
         """Retrieves timestamps when roots where created.
 
         Parameters
         ----------
         root_ids: Iterable of int
             Iterable of root IDs to query.
+        latest: bool, optional
+            If False,  returns the first timestamp that the root_id was valid for each root ID.
+            If True, returns the newest/latest timestamp for each root ID.
+            Note, this will return the timestamp at which the query was run when the root is currently valid.
+            This means that you will get a different answer if you make this same query at a later time
+            if you don't specify a timestamp parameter.
+        timestamp: datetime.datetime, optional
+            Timestamp to query when using latest=True. Use this to provide consistent results for a particular
+            timestamp.If an ID is still valid at a point in the future past this timestamp, the query will still 
+            return this timestamp as the latest moment in time. An error will occur if you provide a timestamp
+            for which the root ID is not valid.
+
+            Defaults to False.
 
         Returns
         -------
@@ -1299,8 +1314,14 @@ class ChunkedGraphClientV1(ClientBase):
         url = self._endpoints["root_timestamps"].format_map(endpoint_mapping)
 
         data = {"node_ids": root_ids}
+        params = {"latest": latest}
+        if timestamp is not None:
+            params.update(package_timestamp(timestamp, name="timestamp"))
+
         r = handle_response(
-            self.session.post(url, data=json.dumps(data, cls=BaseEncoder))
+            self.session.post(
+                url, data=json.dumps(data, cls=BaseEncoder), params=params
+            )
         )
 
         return np.array(


### PR DESCRIPTION
Adds two parameters to `chunkedgraph.get_root_timestamps`:
* `latest`: If True, gives the _latest_ timestamp for which the root id existed. If True, always returns a timestamp during which the root id exists.
* `timestamp`: Provides an explicit latest possible timestamp to use.

Note that the current server side implementation throws a 500 error is the timestamp is too early for the root id to exist yet.