### PR TITLE
Add versioning at the CAVEclient level

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1113,7 +1113,6 @@ class ChunkedGraphClientV1(ClientBase):
         """
         root_id = root_id_int_list_check(root_id, make_unique=True)
 
-        # TODO feels like there should be a timestamp call here if timestamp is set?
         timestamp_future = self.get_root_timestamps(root_id).max()
 
         lineage_graph = self.get_lineage_graph(
@@ -1398,7 +1397,6 @@ class ChunkedGraphClientV1(ClientBase):
         endpoint_mapping = self.default_url_mapping
 
         params = {}
-        # TODO should anything happen with client timestamps here?
         if timestamp_past is not None:
             params.update(package_timestamp(timestamp_past, name="timestamp_past"))
         if timestamp_future is not None:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -219,10 +219,10 @@ class ChunkedGraphClientV1(ClientBase):
 
     @timestamp.setter
     def timestamp(self, value: Optional[datetime.datetime]):
-        if self.fc is not None:
+        if self.fc is not None and self.fc.version is not None:
             msg = (
-                "Cannot set `timestamp` when attached to a CAVEclient, set a "
-                "version at the CAVEclient level instead."
+                "Cannot set `timestamp` when attached to a CAVEclient with a version, "
+                "set a version at the CAVEclient level instead."
             )
             raise ValueError(msg)
         if value is None or isinstance(value, datetime.datetime):

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -190,6 +190,11 @@ class ChunkedGraphClientV1(ClientBase):
         self._segmentation_info = None
 
         # self.timestamp = timestamp
+        if over_client is not None and timestamp is not None:
+            raise ValueError(
+                "Cannot set `timestamp` when attached to a CAVEclient, set a "
+                "version at the CAVEclient level instead."
+            )
         if timestamp is None or isinstance(timestamp, datetime.datetime):
             self._default_timestamp = timestamp
         else:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -218,7 +218,7 @@ class ChunkedGraphClientV1(ClientBase):
         if value is None or isinstance(value, datetime.datetime):
             self._default_timestamp = value
         else:
-            raise ValueError("`timestamp` must be a datetime object or None.")
+            raise TypeError("`timestamp` must be a datetime object or None.")
 
     def _process_timestamp(
         self, timestamp: Optional[datetime.datetime]

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -244,7 +244,7 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel IDs to look up.
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the `timestamp` property for this client, which 
+            default None. If None, uses the `timestamp` property for this client, which
             defaults to the current time.
         stop_layer : int or None, optional
             If True, looks up IDs only up to a given stop layer. Default is None.
@@ -274,7 +274,7 @@ class ChunkedGraphClientV1(ClientBase):
             Supervoxel id value
         timestamp : datetime.datetime, optional
             UTC datetime to specify the state of the chunkedgraph at which to query, by
-            default None. If None, uses the `timestamp` property for this client, which 
+            default None. If None, uses the `timestamp` property for this client, which
             defaults to the current time.
 
         Returns
@@ -950,7 +950,7 @@ class ChunkedGraphClientV1(ClientBase):
         timestamp_past : datetime.datetime or None, optional
             Cutoff for the lineage graph backwards in time. By default, None.
         timestamp_future : datetime.datetime or None, optional
-            Cutoff for the lineage graph going forwards in time. By default, uses the 
+            Cutoff for the lineage graph going forwards in time. By default, uses the
             `timestamp` property for this client, which defaults to the current time.
         as_nx_graph: bool
             If True, a NetworkX graph is returned.
@@ -1066,7 +1066,7 @@ class ChunkedGraphClientV1(ClientBase):
             timestamp = timestamp_future
 
         timestamp = self._process_timestamp(timestamp)
-       
+
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
 
@@ -1138,7 +1138,7 @@ class ChunkedGraphClientV1(ClientBase):
             Root IDs to check.
         timestamp : datetime.datetime, optional
             Timestamp to check whether these IDs are valid root IDs in the chunked
-            graph. If None, uses the `timestamp` property for this client, which 
+            graph. If None, uses the `timestamp` property for this client, which
             defaults to the current time.
 
         Returns
@@ -1186,7 +1186,7 @@ class ChunkedGraphClientV1(ClientBase):
             Root ID of the potentially outdated object.
         timestamp : datetime, optional
             Datetime at which "latest" roots are being computed, by default None. If
-            None, uses the `timestamp` property for this client, which defaults to the 
+            None, uses the `timestamp` property for this client, which defaults to the
             current time. Note that this has to be a timestamp after the creation of the
             `root_id`.
         stop_layer : int, optional
@@ -1273,7 +1273,7 @@ class ChunkedGraphClientV1(ClientBase):
             Defaults to None (assumes now).
         end_timestamp : datetime.datetime, optional
             Timestamp to check whether these IDs were valid before this timestamp.
-            If None, uses the `timestamp` property for this client, which defaults to 
+            If None, uses the `timestamp` property for this client, which defaults to
             the current time.
 
         Returns
@@ -1335,9 +1335,9 @@ class ChunkedGraphClientV1(ClientBase):
             This means that you will get a different answer if you make this same query at a later time
             if you don't specify a timestamp parameter.
         timestamp: datetime.datetime, optional
-            Timestamp to query when using latest=True. Use this to provide consistent 
-            results for a particular timestamp. If an ID is still valid at a point in 
-            the future past this timestamp, the query will still return this timestamp 
+            Timestamp to query when using latest=True. Use this to provide consistent
+            results for a particular timestamp. If an ID is still valid at a point in
+            the future past this timestamp, the query will still return this timestamp
             as the latest moment in time. An error will occur if you provide a timestamp
             for which the root ID is not valid. If None, uses the `timestamp` property
             for this client, which defaults to the current time.

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import logging
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Tuple, Union, Optional
 from urllib.parse import urlencode
 
 import networkx as nx
@@ -197,12 +197,20 @@ class ChunkedGraphClientV1(ClientBase):
     @property
     def table_name(self):
         return self._table_name
+    
+    @property
+    def timestamp(self) -> Optional[datetime.datetime]:
+        if self.fc is None: 
+            return self._default_timestamp
+        else: 
+            return self.fc.timestamp
+        
 
     def _process_timestamp(self, timestamp):
         """Process timestamp with default logic"""
         if timestamp is None:
-            if self._default_timestamp is not None:
-                return self._default_timestamp
+            if self.timestamp is not None:
+                return self.timestamp
             else:
                 return datetime.datetime.now(datetime.timezone.utc)
         else:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -188,17 +188,7 @@ class ChunkedGraphClientV1(ClientBase):
         self._default_url_mapping["table_id"] = table_name
         self._table_name = table_name
         self._segmentation_info = None
-
-        # self.timestamp = timestamp
-        if over_client is not None and timestamp is not None:
-            raise ValueError(
-                "Cannot set `timestamp` when attached to a CAVEclient, set a "
-                "version at the CAVEclient level instead."
-            )
-        if timestamp is None or isinstance(timestamp, datetime.datetime):
-            self._default_timestamp = timestamp
-        else:
-            raise ValueError("`timestamp` must be a datetime object or None.")
+        self._default_timestamp = timestamp
 
     @property
     def default_url_mapping(self):
@@ -212,14 +202,14 @@ class ChunkedGraphClientV1(ClientBase):
     def timestamp(self) -> Optional[datetime.datetime]:
         """The default timestamp for queries which expect a timestamp. If None, uses the
         current time."""
-        if self.fc is None:
+        if self.fc is None or self.fc.timestamp is None:
             return self._default_timestamp
         else:
             return self.fc.timestamp
 
     @timestamp.setter
     def timestamp(self, value: Optional[datetime.datetime]):
-        if self.fc is not None and self.fc.version is not None:
+        if self.fc is not None and self.fc.timestamp is not None:
             msg = (
                 "Cannot set `timestamp` when attached to a CAVEclient with a version, "
                 "set a version at the CAVEclient level instead."

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -186,9 +186,9 @@ class ChunkedGraphClientV1(ClientBase):
             over_client=over_client,
         )
         self._default_url_mapping["table_id"] = table_name
+        self._default_timestamp = timestamp
         self._table_name = table_name
         self._segmentation_info = None
-        self._default_timestamp = timestamp
 
     @property
     def default_url_mapping(self):

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -189,7 +189,11 @@ class ChunkedGraphClientV1(ClientBase):
         self._table_name = table_name
         self._segmentation_info = None
 
-        self.timestamp = timestamp
+        # self.timestamp = timestamp
+        if timestamp is None or isinstance(timestamp, datetime.datetime):
+            self._default_timestamp = timestamp
+        else:
+            raise ValueError("`timestamp` must be a datetime object or None.")
 
     @property
     def default_url_mapping(self):
@@ -210,7 +214,7 @@ class ChunkedGraphClientV1(ClientBase):
 
     @timestamp.setter
     def timestamp(self, value: Optional[datetime.datetime]):
-        if self.fc is not None and value is not None:
+        if self.fc is not None:
             msg = (
                 "Cannot set `timestamp` when attached to a CAVEclient, set a "
                 "version at the CAVEclient level instead."

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from .annotationengine import AnnotationClient, AnnotationClientV2
@@ -390,7 +391,7 @@ class CAVEclientFull(CAVEclientGlobal):
         av_info = self.info.get_aligned_volume_info()
         self._aligned_volume_name = av_info["name"]
 
-        # this uses the setter, and also interprets the timestamp
+        # this uses the setter, and also sets the timestamp
         self.version = version
 
     @property
@@ -412,6 +413,10 @@ class CAVEclientFull(CAVEclientGlobal):
                 )
         else:
             raise ValueError("Version must be an integer or None.")
+
+    @property
+    def timestamp(self) -> Optional[datetime]:
+        return self._timestamp
 
     def _reset_services(self):
         self._auth = None
@@ -446,7 +451,6 @@ class CAVEclientFull(CAVEclientGlobal):
                 pool_maxsize=self._pool_maxsize,
                 pool_block=self._pool_block,
                 over_client=self,
-                timestamp=self.timestamp,
             )
         return self._chunkedgraph
 

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -412,7 +412,7 @@ class CAVEclientFull(CAVEclientGlobal):
                     f"Version {version} is not available for this datastack."
                 )
         else:
-            raise ValueError("Version must be an integer or None.")
+            raise TypeError("Version must be an integer or None.")
 
     @property
     def timestamp(self) -> Optional[datetime]:

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -291,7 +291,7 @@ class MaterializationClientV2(ClientBase):
         if self.fc is not None:
             msg = (
                 "Cannot set version for materialization client when attached to a "
-                "framework client, set at the framework client level instead."
+                "framework client, set at the CAVEclient level instead."
             )
             raise ValueError(msg)
         if int(x) in self.get_versions(expired=True):

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -276,6 +276,8 @@ class MaterializationClientV2(ClientBase):
         """The version of the materialization. Can be used to set up the
         client to default to a specific version when timestamps or versions are not
         specified in queries. If not set, defaults to the most recent version."""
+        if self.fc is not None: 
+            return self.fc.version
         if self._version is None:
             self._version = self.most_recent_version()
         return self._version

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -276,7 +276,7 @@ class MaterializationClientV2(ClientBase):
         """The version of the materialization. Can be used to set up the
         client to default to a specific version when timestamps or versions are not
         specified in queries. If not set, defaults to the most recent version.
-        
+
         Note that if this materialization client is attached to a framework client,
         the version must be set at the framework client level.
         """

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -280,7 +280,7 @@ class MaterializationClientV2(ClientBase):
         Note that if this materialization client is attached to a framework client,
         the version must be set at the framework client level.
         """
-        if self.fc is not None:
+        if self.fc is not None and self.fc.version is not None:
             return self.fc.version
         if self._version is None:
             self._version = self.most_recent_version()
@@ -503,7 +503,7 @@ class MaterializationClientV2(ClientBase):
         self,
         table_name: str,
         datastack_name=None,
-        version: int = None,
+        version: Optional[int] = None,
         log_warning: bool = True,
     ):
         """Get metadata about a table

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -288,10 +288,10 @@ class MaterializationClientV2(ClientBase):
 
     @version.setter
     def version(self, x: Optional[int]):
-        if self.fc is not None:
+        if self.fc is not None and self.fc.version is not None:
             msg = (
-                "Cannot set version for materialization client when attached to a "
-                "framework client, set at the CAVEclient level instead."
+                "Cannot set `version` for materialization client when attached to a "
+                "CAVEclient with a version, set at the CAVEclient level instead."
             )
             raise ValueError(msg)
         if int(x) in self.get_versions(expired=True):

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -277,8 +277,8 @@ class MaterializationClientV2(ClientBase):
         client to default to a specific version when timestamps or versions are not
         specified in queries. If not set, defaults to the most recent version.
 
-        Note that if this materialization client is attached to a framework client,
-        the version must be set at the framework client level.
+        Note that if this materialization client is attached to a CAVEclient,
+        the version must be set at the CAVEclient level.
         """
         if self.fc is not None and self.fc.version is not None:
             return self.fc.version
@@ -373,7 +373,7 @@ class MaterializationClientV2(ClientBase):
         self.raise_for_status(response)
         return response.json()
 
-    def get_tables(self, datastack_name=None, version=None):
+    def get_tables(self, datastack_name=None, version: Optional[int] = None):
         """Gets a list of table names for a datastack
 
         Parameters
@@ -383,7 +383,8 @@ class MaterializationClientV2(ClientBase):
             If None, uses the one specified in the client.
             Will be set correctly if you are using the framework_client
         version : int or None, optional
-            the version to query, else get the tables in the most recent version
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
 
         Returns
         -------
@@ -419,13 +420,16 @@ class MaterializationClientV2(ClientBase):
         self.raise_for_status(response)
         return response.json()
 
-    def get_version_metadata(self, version: int = None, datastack_name: str = None):
+    def get_version_metadata(
+        self, version: Optional[int] = None, datastack_name: str = None
+    ):
         """Get metadata about a version
 
         Parameters
         ----------
         version : int or None, optional
-            Materialization version, by default None. If None, defaults to the value set in the client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         datastack_name : str or None, optional
             Datastack name, by default None. If None, defaults to the value set in the client.
 
@@ -450,13 +454,14 @@ class MaterializationClientV2(ClientBase):
         d["expires_on"] = convert_timestamp(d["expires_on"])
         return d
 
-    def get_timestamp(self, version: int = None, datastack_name: str = None):
+    def get_timestamp(self, version: Optional[int] = None, datastack_name: str = None):
         """Get datetime.datetime timestamp for a materialization version.
 
         Parameters
         ----------
         version : int or None, optional
-            Materialization version, by default None. If None, defaults to the value set in the client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         datastack_name : str or None, optional
             Datastack name, by default None. If None, defaults to the value set in the client.
 
@@ -515,7 +520,8 @@ class MaterializationClientV2(ClientBase):
         datastack_name : str or None, optional
             Name of the datastack_name. If None, uses the one specified in the client.
         version : int, optional
-            Version to get. If None, uses the one specified in the client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         log_warning : bool, optional
             Whether to print out warnings to the logger. Defaults to True.
 
@@ -672,7 +678,7 @@ class MaterializationClientV2(ClientBase):
         datastack_name: str = None,
         return_df: bool = True,
         split_positions: bool = False,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         timestamp: Optional[datetime] = None,
         metadata: bool = True,
         merge_reference: bool = True,
@@ -714,8 +720,8 @@ class MaterializationClientV2(ClientBase):
             Whether to break position columns into x,y,z columns, by default False.
             If False data is returned as one column with [x,y,z] array (slower)
         materialization_version : int, optional
-            Version to query, by default None.
-            If None, defaults to one specified in client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         timestamp : datetime.datetime, optional
             Timestamp to query, by default None. If passsed will do a live query.
             Error if also passing a materialization version
@@ -919,7 +925,8 @@ class MaterializationClientV2(ClientBase):
             whether to break position columns into x,y,z columns default False, if False
             data is returned as one column with [x,y,z] array (slower)
         materialization_version : int, optional
-            version to query. If None defaults to one specified in client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         metadata : bool, optional
             toggle to return metadata If True (and return_df is also True), return
             table and query metadata in the df.attr dictionary.
@@ -1726,7 +1733,7 @@ class MaterializationClientV2(ClientBase):
         offset: int = None,
         split_positions: bool = False,
         desired_resolution: Iterable[float] = None,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         synapse_table: str = None,
         datastack_name: str = None,
         metadata: bool = True,
@@ -1768,8 +1775,8 @@ class MaterializationClientV2(ClientBase):
             List or array of the desired resolution you want queries returned in
             useful for materialization queries.
         materialization_version:
-            Version to query. If passed, do not pass timestamp. Defaults to
-            `self.materialization_version` if not specified.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         metadata:
             Whether to attach metadata to dataframe in the df.attr dictionary.
 
@@ -1927,7 +1934,7 @@ class MaterializationClientV3(MaterializationClientV2):
         if self._tables is None:
             if self.fc is not None and self.fc._materialize is not None:
                 metadata = []
-                with ThreadPoolExecutor(max_workers=4) as executor:
+                with ThreadPoolExecutor(max_workers=2) as executor:
                     metadata.append(
                         executor.submit(
                             self.get_tables_metadata,
@@ -1945,7 +1952,7 @@ class MaterializationClientV3(MaterializationClientV2):
                         self.fc, metadata[0].result(), metadata[1].result()
                     )
                 else:
-                    # TODO is this right?
+                    # TODO fix this for when the metadata is not available
                     tables = None
                 self._tables = tables
             else:
@@ -1958,7 +1965,7 @@ class MaterializationClientV3(MaterializationClientV2):
         if self._views is None:
             if self.fc is not None and self.fc._materialize is not None:
                 metadata = []
-                with ThreadPoolExecutor(max_workers=4) as executor:
+                with ThreadPoolExecutor(max_workers=2) as executor:
                     metadata.append(
                         executor.submit(
                             self.get_views,
@@ -1976,7 +1983,7 @@ class MaterializationClientV3(MaterializationClientV2):
     def get_tables_metadata(
         self,
         datastack_name=None,
-        version: int = None,
+        version: Optional[int] = None,
         log_warning: bool = True,
     ) -> dict:
         """Get metadata about tables
@@ -1986,7 +1993,8 @@ class MaterializationClientV3(MaterializationClientV2):
         datastack_name : str or None, optional
             Name of the datastack_name. If None, uses the one specified in the client.
         version :
-            Version to get. If None, uses the one specified in the client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         log_warning :
             Whether to print out warnings to the logger. Defaults to True.
 
@@ -2248,14 +2256,15 @@ it will likely get removed in future versions. "
                 )
         return df
 
-    def get_views(self, version: int = None, datastack_name: str = None):
+    def get_views(self, version: Optional[int] = None, datastack_name: str = None):
         """
         Get all available views for a version
 
         Parameters
         ----------
         version :
-            Version to query. If None, uses the one specified in the client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         datastack_name :
             Datastack to query. If None, uses the one specified in the client.
 
@@ -2279,7 +2288,7 @@ it will likely get removed in future versions. "
     def get_view_metadata(
         self,
         view_name: str,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         datastack_name: str = None,
         log_warning: bool = True,
     ):
@@ -2290,7 +2299,8 @@ it will likely get removed in future versions. "
         view_name :
             Name of view to query.
         materialization_version :
-            Version to query. If None, will use version set by client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         log_warning :
             Whether to log warnings.
 
@@ -2317,7 +2327,7 @@ it will likely get removed in future versions. "
     def get_view_schema(
         self,
         view_name: str,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         datastack_name: str = None,
         log_warning: bool = True,
     ):
@@ -2328,7 +2338,8 @@ it will likely get removed in future versions. "
         view_name:
             Name of view to query.
         materialization_version:
-            Version to query. If None, will use version set by client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         log_warning:
             Whether to log warnings.
 
@@ -2354,7 +2365,7 @@ it will likely get removed in future versions. "
 
     def get_view_schemas(
         self,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         datastack_name: str = None,
         log_warning: bool = True,
     ):
@@ -2400,7 +2411,7 @@ it will likely get removed in future versions. "
         datastack_name: str = None,
         return_df: bool = True,
         split_positions: bool = False,
-        materialization_version: int = None,
+        materialization_version: Optional[int] = None,
         metadata: bool = True,
         merge_reference: bool = True,
         desired_resolution: Iterable = None,
@@ -2441,8 +2452,8 @@ it will likely get removed in future versions. "
             Whether to break position columns into x,y,z columns, by default False.
             If False data is returned as one column with [x,y,z] array (slower)
         materialization_version : int, optional
-            Version to query, by default None.
-            If None, defaults to one specified in client.
+            The version of the datastack to query. If None, will query the client
+            `version`, which defaults to the most recent version.
         metadata : bool, optional
             Toggle to return metadata (default True), by default True. If True
             (and return_df is also True), return table and query metadata in the

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -74,7 +74,9 @@ class TestChunkedgraph:
             body=root_ids.tobytes(),
             # match=[binary_body_match(svids.tobytes())],
         )
-        new_root_ids = myclient.chunkedgraph.get_roots(svids, timestamp=now, stop_layer=3)
+        new_root_ids = myclient.chunkedgraph.get_roots(
+            svids, timestamp=now, stop_layer=3
+        )
         assert np.all(new_root_ids == root_ids)
 
         endpoint_mapping["supervoxel_id"] = svids[0]

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -59,7 +59,7 @@ class TestChunkedgraph:
             # match=[binary_body_match(svids.tobytes())],
         )
 
-        # detach the parent client just to be able to set a default timestamp for 
+        # detach the parent client just to be able to set a default timestamp for
         # the chunkedgraph client
         cg = myclient.chunkedgraph
         cg._fc = None
@@ -79,9 +79,7 @@ class TestChunkedgraph:
             body=root_ids.tobytes(),
             # match=[binary_body_match(svids.tobytes())],
         )
-        new_root_ids = cg.get_roots(
-            svids, timestamp=now, stop_layer=3
-        )
+        new_root_ids = cg.get_roots(svids, timestamp=now, stop_layer=3)
         assert np.all(new_root_ids == root_ids)
 
         endpoint_mapping["supervoxel_id"] = svids[0]

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -59,15 +59,10 @@ class TestChunkedgraph:
             # match=[binary_body_match(svids.tobytes())],
         )
 
-        # detach the parent client just to be able to set a default timestamp for
-        # the chunkedgraph client
-        cg = myclient.chunkedgraph
-        cg._fc = None
-
-        new_root_ids = cg.get_roots(svids, timestamp=now)
+        new_root_ids = myclient.chunkedgraph.get_roots(svids, timestamp=now)
         assert np.all(new_root_ids == root_ids)
-        cg._default_timestamp = now
-        new_root_ids = cg.get_roots(svids)
+        myclient.chunkedgraph._default_timestamp = now
+        new_root_ids = myclient.chunkedgraph.get_roots(svids)
         assert np.all(new_root_ids == root_ids)
 
         query_d = package_timestamp(now)
@@ -79,7 +74,7 @@ class TestChunkedgraph:
             body=root_ids.tobytes(),
             # match=[binary_body_match(svids.tobytes())],
         )
-        new_root_ids = cg.get_roots(svids, timestamp=now, stop_layer=3)
+        new_root_ids = myclient.chunkedgraph.get_roots(svids, timestamp=now, stop_layer=3)
         assert np.all(new_root_ids == root_ids)
 
         endpoint_mapping["supervoxel_id"] = svids[0]

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -59,10 +59,15 @@ class TestChunkedgraph:
             # match=[binary_body_match(svids.tobytes())],
         )
 
-        new_root_ids = myclient.chunkedgraph.get_roots(svids, timestamp=now)
+        # detach the parent client just to be able to set a default timestamp for 
+        # the chunkedgraph client
+        cg = myclient.chunkedgraph
+        cg._fc = None
+
+        new_root_ids = cg.get_roots(svids, timestamp=now)
         assert np.all(new_root_ids == root_ids)
-        myclient.chunkedgraph._default_timestamp = now
-        new_root_ids = myclient.chunkedgraph.get_roots(svids)
+        cg._default_timestamp = now
+        new_root_ids = cg.get_roots(svids)
         assert np.all(new_root_ids == root_ids)
 
         query_d = package_timestamp(now)
@@ -74,7 +79,7 @@ class TestChunkedgraph:
             body=root_ids.tobytes(),
             # match=[binary_body_match(svids.tobytes())],
         )
-        new_root_ids = myclient.chunkedgraph.get_roots(
+        new_root_ids = cg.get_roots(
             svids, timestamp=now, stop_layer=3
         )
         assert np.all(new_root_ids == root_ids)

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,0 +1,118 @@
+import datetime
+
+import responses
+from pytest import raises as assert_raises
+from responses.matchers import query_param_matcher
+
+from caveclient import CAVEclient, endpoints
+
+from .conftest import TEST_DATASTACK, TEST_GLOBAL_SERVER, TEST_LOCAL_SERVER, test_info
+
+default_mapping = {
+    "me_server_address": TEST_LOCAL_SERVER,
+    "cg_server_address": TEST_LOCAL_SERVER,
+    "table_id": test_info["segmentation_source"].split("/")[-1],
+    "datastack_name": TEST_DATASTACK,
+    "table_name": test_info["synapse_table"],
+    "version": 1,
+}
+
+
+url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
+mapping = {"i_server_address": TEST_GLOBAL_SERVER, "datastack_name": TEST_DATASTACK}
+info_url = url_template.format_map(mapping)
+
+
+class TestFrameworkClient:
+    default_mapping = {
+        "me_server_address": TEST_LOCAL_SERVER,
+        "cg_server_address": TEST_LOCAL_SERVER,
+        "table_id": test_info["segmentation_source"].split("/")[-1],
+        "datastack_name": TEST_DATASTACK,
+        "table_name": test_info["synapse_table"],
+        "version": 1,
+    }
+
+    @responses.activate
+    def test_create_client(self):
+        responses.add(responses.GET, info_url, json=test_info, status=200)
+        _ = CAVEclient(
+            TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
+        )
+
+    @responses.activate
+    def test_create_versioned_client(self):
+        responses.add(responses.GET, info_url, json=test_info, status=200)
+
+        endpoint_mapping = self.default_mapping
+        endpoint_mapping["emas_server_address"] = TEST_GLOBAL_SERVER
+
+        print(endpoints.chunkedgraph_endpoints_common.keys())
+        api_versions_url = endpoints.chunkedgraph_endpoints_common[
+            "get_api_versions"
+        ].format_map(endpoint_mapping)
+        responses.add(responses.GET, url=api_versions_url, json=[0, 1], status=200)
+
+        version_url = endpoints.chunkedgraph_endpoints_common["get_version"].format_map(
+            endpoint_mapping
+        )
+        responses.add(responses.GET, version_url, json="2.15.0", status=200)
+
+        responses.add(
+            responses.GET,
+            url=endpoints.materialization_common["get_api_versions"].format_map(
+                endpoint_mapping
+            ),
+            json=[3],
+            status=200,
+        )
+
+        versionurl = endpoints.materialization_endpoints_v3["versions"].format_map(
+            endpoint_mapping
+        )
+        responses.add(
+            responses.GET,
+            url=versionurl,
+            json=[1, 2],
+            status=200,
+            match=[query_param_matcher({"expired": True})],
+        )
+
+        version_metadata_url = endpoints.materialization_endpoints_v3[
+            "version_metadata"
+        ].format_map(endpoint_mapping)
+
+        responses.add(
+            responses.GET,
+            url=version_metadata_url,
+            json={
+                "time_stamp": "2024-06-05T10:10:01.203215",
+                "expires_on": "2080-06-05T10:10:01.203215",
+            },
+            status=200,
+        )
+
+        with assert_raises(ValueError):
+            _ = CAVEclient(
+                TEST_DATASTACK,
+                server_address=TEST_GLOBAL_SERVER,
+                write_server_cache=False,
+                version=10,
+            )
+
+        versioned_client = CAVEclient(
+            TEST_DATASTACK,
+            server_address=TEST_GLOBAL_SERVER,
+            write_server_cache=False,
+            version=1,
+        )
+
+        correct_date = datetime.datetime.strptime(
+            "2024-06-05T10:10:01.203215", "%Y-%m-%dT%H:%M:%S.%f"
+        ).replace(tzinfo=datetime.timezone.utc)
+
+        assert versioned_client.timestamp == correct_date
+
+        assert versioned_client.materialize.version == 1
+
+        assert versioned_client.chunkedgraph.timestamp == correct_date

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -467,9 +467,6 @@ class TestMatclient:
 
         meta_url = self.endpoints["metadata"].format_map(endpoint_mapping)
         responses.add(responses.GET, url=meta_url, json=self.table_metadata)
-        print(myclient.version)
-        print(myclient.materialize.version)
-        print(myclient.materialize.most_recent_version())
         df = myclient.materialize.query_table(
             test_info["synapse_table"],
             filter_in_dict={"pre_pt_root_id": [500]},

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -479,7 +479,7 @@ class TestMatclient:
             offset=0,
         )
         assert len(df) == 1000
-        assert type(df) == pd.DataFrame
+        assert isinstance(df, pd.DataFrame)
         assert df.attrs["table_id"] == self.table_metadata["id"]
 
         correct_metadata = [

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -467,7 +467,9 @@ class TestMatclient:
 
         meta_url = self.endpoints["metadata"].format_map(endpoint_mapping)
         responses.add(responses.GET, url=meta_url, json=self.table_metadata)
-
+        print(myclient.version)
+        print(myclient.materialize.version)
+        print(myclient.materialize.most_recent_version())
         df = myclient.materialize.query_table(
             test_info["synapse_table"],
             filter_in_dict={"pre_pt_root_id": [500]},


### PR DESCRIPTION
- Closes https://github.com/CAVEconnectome/CAVEclient/issues/191
- Closes https://github.com/CAVEconnectome/CAVEclient/issues/198
- Adds the ability to set a `version` during or after initialization for a CAVEclient
   - This version also sets the corresponding `timestamp` for that version
   - Currently only lets you set `version` directly, `timestamp` can't be set on its own
      - This is up for debate - but I found it clunky to deal with either or both, there are many functions in materialization that only expect a version (so the behavior feels slightly unclear to me if only a timestamp is set), and I feel setting the version covers 99% of use cases anyway. 
- Changes logic for `MaterializationClient` and `ChunkedGraphClient` to defer to the `version`/`timestamp` if it is set at the `CAVEclient` level