### PR TITLE
fix version constraints for get root timestamps

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -433,10 +433,12 @@ def _check_version_compatibility(
         if method_constraint is not None:
             if _version_fails_constraint(self.server_version, method_constraint):
                 if isinstance(method_constraint, str):
-                    method_constraint = [method_constraint]
+                    ms_list = [method_constraint]
+                else:
+                    ms_list = method_constraint
                 msg = (
                     f"Use of method `{method.__name__}` is only permitted "
-                    f"for server version {' or '.join(method_constraint)}, your server "
+                    f"for server version {' or '.join(ms_list)}. Your server "
                     f"version is {self.server_version}. Contact your system "
                     "administrator to update the server version."
                 )
@@ -455,11 +457,13 @@ def _check_version_compatibility(
                     continue
                 elif _version_fails_constraint(self.server_version, kwarg_constraint):
                     if isinstance(kwarg_constraint, str):
-                        kwarg_constraint = [kwarg_constraint]
+                        kw_list = [kwarg_constraint]
+                    else:
+                        kw_list = kwarg_constraint
                     msg = (
                         f"Use of keyword argument `{kwarg}` in `{method.__name__}` "
                         "is only permitted "
-                        f"for server version {' or '.join(kwarg_constraint)}, your server "
+                        f"for server version {' or '.join(kw_list)}. Your server "
                         f"version is {self.server_version}. Contact your system "
                         "administrator to update the server version."
                     )

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -432,9 +432,11 @@ def _check_version_compatibility(
 
         if method_constraint is not None:
             if _version_fails_constraint(self.server_version, method_constraint):
+                if isinstance(method_constraint, str):
+                    method_constraint = [method_constraint]
                 msg = (
                     f"Use of method `{method.__name__}` is only permitted "
-                    f"for server version {method_constraint}, your server "
+                    f"for server version {' or '.join(method_constraint)}, your server "
                     f"version is {self.server_version}. Contact your system "
                     "administrator to update the server version."
                 )
@@ -452,10 +454,12 @@ def _check_version_compatibility(
                 if check_kwargs.get(kwarg, None) is None:
                     continue
                 elif _version_fails_constraint(self.server_version, kwarg_constraint):
+                    if isinstance(kwarg_constraint, str):
+                        kwarg_constraint = [kwarg_constraint]
                     msg = (
                         f"Use of keyword argument `{kwarg}` in `{method.__name__}` "
                         "is only permitted "
-                        f"for server version {kwarg_constraint}, your server "
+                        f"for server version {' or '.join(kwarg_constraint)}, your server "
                         f"version is {self.server_version}. Contact your system "
                         "administrator to update the server version."
                     )

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1316,8 +1316,8 @@ class ChunkedGraphClientV1(ClientBase):
 
     @_check_version_compatibility(
         kwarg_use_constraints={
-            "latest": ["<2,>=1.25.0", ">1,>=2.17.0"],
-            "timestamp": ["<2,>=1.25.0", ">1,>=2.17.0"],
+            "latest": ["<2,>=1.25.0", "<3,>=2.17.0"],
+            "timestamp": ["<2,>=1.25.0", "<3,>=2.17.0"],
         }
     )
     def get_root_timestamps(

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1316,8 +1316,8 @@ class ChunkedGraphClientV1(ClientBase):
 
     @_check_version_compatibility(
         kwarg_use_constraints={
-            "latest": [">=2.17.0", ">=1.25.0"],
-            "timestamp": [">=2.17.0", ">=1.25.0"],
+            "latest": ["<2,>=1.25.0", ">1,>=2.17.0"],
+            "timestamp": ["<2,>=1.25.0", ">1,>=2.17.0"],
         }
     )
     def get_root_timestamps(


### PR DESCRIPTION
Tweak version constraint to limit on minor versions within the major-version