### PR TITLE
update get roots timestamp latest

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1339,8 +1339,8 @@ class ChunkedGraphClientV1(ClientBase):
             Timestamp to query when using latest=True. Use this to provide consistent
             results for a particular timestamp. If an ID is still valid at a point in
             the future past this timestamp, the query will still return this timestamp
-            as the latest moment in time. An error will occur if you provide a timestamp
-            for which the root ID is not valid. If None, uses the `timestamp` property
+            as the latest moment in time. If a root id is not yet created by the timestamp,
+            the value for that entry will be None. If None, uses the `timestamp` property
             for this client, which defaults to the current time.
 
         Returns

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1316,8 +1316,8 @@ class ChunkedGraphClientV1(ClientBase):
 
     @_check_version_compatibility(
         kwarg_use_constraints={
-            "latest": ["<2,>=1.25.0", "<3,>=2.17.0"],
-            "timestamp": ["<2,>=1.25.0", "<3,>=2.17.0"],
+            "latest": ["<2,>=1.25.0", "<3,>=2.16.2"],
+            "timestamp": ["<2,>=1.25.0", "<3,>=2.16.2"],
         }
     )
     def get_root_timestamps(
@@ -1347,6 +1347,7 @@ class ChunkedGraphClientV1(ClientBase):
         -------
         np.array of datetime.datetime
             Array of timestamps when `root_ids` were created.
+            If a root id was not yet created by the timestamp (if provided), it will have an entry of None.
         """
         root_ids = root_id_int_list_check(root_ids, make_unique=False)
 
@@ -1373,6 +1374,8 @@ class ChunkedGraphClientV1(ClientBase):
         return np.array(
             [
                 datetime.datetime.fromtimestamp(ts, pytz.UTC) - delta_t
+                if ts != 0
+                else None
                 for ts in r["timestamp"]
             ]
         )


### PR DESCRIPTION
1) Fixes the constraints to the correct pcg versions with the new releases.

2) Fixes the behavior to replace a response of `0` with `None` in the case where a root id has not yet been created by a provided timestamp.

We could instead show a value error if there are any 0s in the response and show the offending root ids. Happy to do either.