### PR TITLE
Fix possible issue with `synapse_query` backwards compatibility

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -1997,10 +1997,6 @@ class MaterializationClientV2(ClientBase):
         """
         filter_in_dict = {}
         filter_equal_dict = {}
-        filter_greater_dict = {}
-        filter_less_dict = {}
-        filter_greater_equal_dict = {}
-        filter_less_equal_dict = {}
         filter_out_dict = None
         filter_spatial_dict = None
         if synapse_table is None:
@@ -2032,10 +2028,6 @@ class MaterializationClientV2(ClientBase):
             filter_in_dict=filter_in_dict,
             filter_out_dict=filter_out_dict,
             filter_equal_dict=filter_equal_dict,
-            filter_greater_dict=filter_greater_dict,
-            filter_less_dict=filter_less_dict,
-            filter_greater_equal_dict=filter_greater_equal_dict,
-            filter_less_equal_dict=filter_less_equal_dict,
             filter_spatial_dict=filter_spatial_dict,
             offset=offset,
             limit=limit,


### PR DESCRIPTION
Due to the details of how the version checking decorator works, passing in (even empty) dictionaries to the new inequality filters would throw an error if running older versions of the materialization engine