### PR TITLE
Mock CAVEclient for testing

### DIFF
--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -238,7 +238,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         switch_token: bool = True,
         write_to_server_file: bool = True,
         ignore_readonly: bool = True,
-        local_server: bool = False,
+        local_server: bool = True,
     ):
         """Conveniently save a token in the correct format.
 

--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -238,6 +238,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         switch_token: bool = True,
         write_to_server_file: bool = True,
         ignore_readonly: bool = True,
+        local_server: bool = False,
     ):
         """Conveniently save a token in the correct format.
 
@@ -267,6 +268,8 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
             interacting with multiple auth servers.
         ignore_readonly: bool, optional
             If True, will only attempt to save a token if the directory is writeable.
+        local_server: bool, optional
+            If True, saves the token to the local server file as well.
         """
         if token is None:
             token = self.token
@@ -298,6 +301,9 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
             self._token = token
             self._token_key = token_key
             self._token_file = save_token_file
+
+        if local_server:
+            self._synchronize_local_server_file(token)
 
     def get_user_information(self, user_ids):
         """Get user data.
@@ -360,26 +366,24 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         else:
             return None
 
-    def write_local_server_token(self):
-        """Write the token secret into a file that can be used to authenticate with the local server (e.g. segmentation) from cloudvolume."""
-        self._synchronize_local_server_file()
-
-    def _synchronize_local_server_file(self):
+    def _synchronize_local_server_file(self, token=None):
+        if token is None:
+            token = self.token
         if self.local_server:
             if os.path.exists(self.local_server_filepath):
                 local_token = self._load_token(
                     self.local_server_filepath, self._token_key
                 )
-                if local_token != self.token:
+                if local_token != token:
                     self.save_token(
-                        token=self.token,
+                        token=token,
                         token_file=self.local_server_filepath,
                         overwrite=True,
                         ignore_readonly=True,
                     )
             else:
                 self.save_token(
-                    token=self.token,
+                    token=token,
                     token_file=self.local_server_filepath,
                     overwrite=True,
                     ignore_readonly=True,

--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -352,7 +352,6 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
     @local_server.setter
     def local_server(self, new_val):
         self._local_server = new_val
-        self._synchronize_local_server_file()
 
     @property
     def local_server_filepath(self):
@@ -360,6 +359,10 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
             return server_token_filename(self.local_server)
         else:
             return None
+
+    def write_local_server_token(self):
+        """Write the token secret into a file that can be used to authenticate with the local server (e.g. segmentation) from cloudvolume."""
+        self._synchronize_local_server_file()
 
     def _synchronize_local_server_file(self):
         if self.local_server:

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -103,10 +103,6 @@ class CAVEclient(object):
             If True, synchronizes the auth token for datastack-specific services in your secrets directory.
             Does nothing if no datastack is set.
         """
-        server_address = handle_server_address(
-            datastack_name, server_address, write=write_server_cache
-        )
-
         if global_only or datastack_name is None:
             return CAVEclientGlobal(
                 server_address=server_address,
@@ -119,6 +115,10 @@ class CAVEclient(object):
                 info_cache=info_cache,
             )
         else:
+            server_address = handle_server_address(
+                datastack_name, server_address, write=write_server_cache
+            )
+
             return CAVEclientFull(
                 datastack_name=datastack_name,
                 server_address=server_address,

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -34,7 +34,6 @@ class CAVEclient(object):
         info_cache=None,
         write_server_cache=True,
         version: Optional[int] = None,
-        write_local_auth=True,
     ):
         """A manager for all clients sharing common datastack and authentication information.
 
@@ -131,7 +130,6 @@ class CAVEclient(object):
                 desired_resolution=desired_resolution,
                 info_cache=info_cache,
                 version=version,
-                write_local_auth=write_local_auth,
             )
 
 
@@ -349,7 +347,6 @@ class CAVEclientFull(CAVEclientGlobal):
         desired_resolution=None,
         info_cache=None,
         version: Optional[int] = None,
-        write_local_auth: bool = True,
     ):
         """A manager for all clients sharing common datastack and authentication information.
 
@@ -436,8 +433,7 @@ class CAVEclientFull(CAVEclientGlobal):
         self._l2cache = None
         self.desired_resolution = desired_resolution
         self.local_server = self.info.local_server()
-        if write_local_auth:
-            self.auth.local_server = self.local_server
+        self.auth.local_server = self.local_server
 
         av_info = self.info.get_aligned_volume_info()
         self._aligned_volume_name = av_info["name"]

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -98,9 +98,6 @@ class CAVEclient(object):
         version:
             The default materialization version of the datastack to use. If None, the
             latest version is used. Optional, defaults to None.
-        write_local_auth: bool, optional
-            If True, synchronizes the auth token for datastack-specific services in your secrets directory.
-            Does nothing if no datastack is set.
         """
         if global_only or datastack_name is None:
             return CAVEclientGlobal(
@@ -403,8 +400,6 @@ class CAVEclientFull(CAVEclientGlobal):
         version:
             The default materialization version of the datastack to use. If None, the
             latest version is used. Optional, defaults to None.
-        write_local_auth: bool, optional
-            If True, synchronizes the auth token for datastack-specific services in your secrets directory.
 
         See Also
         --------

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -34,6 +34,7 @@ class CAVEclient(object):
         info_cache=None,
         write_server_cache=True,
         version: Optional[int] = None,
+        write_local_auth=True,
     ):
         """A manager for all clients sharing common datastack and authentication information.
 
@@ -98,6 +99,9 @@ class CAVEclient(object):
         version:
             The default materialization version of the datastack to use. If None, the
             latest version is used. Optional, defaults to None.
+        write_local_auth: bool, optional
+            If True, synchronizes the auth token for datastack-specific services in your secrets directory.
+            Does nothing if no datastack is set.
         """
         server_address = handle_server_address(
             datastack_name, server_address, write=write_server_cache
@@ -127,6 +131,7 @@ class CAVEclient(object):
                 desired_resolution=desired_resolution,
                 info_cache=info_cache,
                 version=version,
+                write_local_auth=write_local_auth,
             )
 
 
@@ -206,7 +211,12 @@ class CAVEclientGlobal(object):
         self._pool_block = pool_block
         self._info_cache = info_cache
 
-    def change_auth(self, auth_token_file=None, auth_token_key=None, auth_token=None):
+    def change_auth(
+        self,
+        auth_token_file=None,
+        auth_token_key=None,
+        auth_token=None,
+    ):
         """Change the authentication token and reset services.
 
         Parameters
@@ -339,6 +349,7 @@ class CAVEclientFull(CAVEclientGlobal):
         desired_resolution=None,
         info_cache=None,
         version: Optional[int] = None,
+        write_local_auth: bool = True,
     ):
         """A manager for all clients sharing common datastack and authentication information.
 
@@ -395,6 +406,8 @@ class CAVEclientFull(CAVEclientGlobal):
         version:
             The default materialization version of the datastack to use. If None, the
             latest version is used. Optional, defaults to None.
+        write_local_auth: bool, optional
+            If True, synchronizes the auth token for datastack-specific services in your secrets directory.
 
         See Also
         --------
@@ -423,7 +436,8 @@ class CAVEclientFull(CAVEclientGlobal):
         self._l2cache = None
         self.desired_resolution = desired_resolution
         self.local_server = self.info.local_server()
-        self.auth.local_server = self.local_server
+        if write_local_auth:
+            self.auth.local_server = self.local_server
 
         av_info = self.info.get_aligned_volume_info()
         self._aligned_volume_name = av_info["name"]

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -55,6 +55,7 @@ class L2CacheClient(ClientBase):
         )
         self._default_url_mapping["table_id"] = table_name
         self._available_attributes = None
+        self._table_mapping = None
 
     @property
     def default_url_mapping(self):
@@ -123,10 +124,12 @@ class L2CacheClient(ClientBase):
         dict
             keys are pcg table names, values are dicts with fields `l2cache_id` and `cv_path`.
         """
-        endpoint_mapping = self.default_url_mapping
-        url = self._endpoints["l2cache_table_mapping"].format_map(endpoint_mapping)
-        response = self.session.get(url)
-        return handle_response(response)
+        if self._table_mapping is None:
+            endpoint_mapping = self.default_url_mapping
+            url = self._endpoints["l2cache_table_mapping"].format_map(endpoint_mapping)
+            response = self.session.get(url)
+            self._table_mapping = handle_response(response)
+        return self._table_mapping
 
     def has_cache(self, datastack_name=None):
         """Checks if the l2 cache is available for the dataset

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -1,5 +1,6 @@
 import os
-from caveclient import CAVEclient, endpoints
+from ..frameworkclient import CAVEclient
+from .. import endpoints
 
 try:
     import responses
@@ -12,24 +13,26 @@ TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
 TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
 TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
 
-default_info = {
-    "viewer_site": "http://neuromancer-seung-import.appspot.com/",
-    "aligned_volume": {
-        "name": "test_volume",
-        "image_source": f"precomputed://https://{TEST_LOCAL_SERVER}/test-em/v1",
-        "id": 1,
-        "description": "This is a test only dataset.",
-    },
-    "synapse_table": "test_synapse_table",
-    "description": "This is the first test datastack.",
-    "local_server": TEST_LOCAL_SERVER,
-    "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
-    "soma_table": "test_soma",
-    "analysis_database": None,
-    "viewer_resolution_x": 4.0,
-    "viewer_resolution_y": 4.0,
-    "viewer_resolution_z": 40,
-}
+
+def default_info(local_server):
+    return {
+        "viewer_site": "http://neuromancer-seung-import.appspot.com/",
+        "aligned_volume": {
+            "name": "test_volume",
+            "image_source": f"precomputed://https://{local_server}/test-em/v1",
+            "id": 1,
+            "description": "This is a test only dataset.",
+        },
+        "synapse_table": "test_synapse_table",
+        "description": "This is the first test datastack.",
+        "local_server": local_server,
+        "segmentation_source": f"graphene://https://{local_server}/segmentation/table/test_v1",
+        "soma_table": "test_soma",
+        "analysis_database": None,
+        "viewer_resolution_x": 4.0,
+        "viewer_resolution_y": 4.0,
+        "viewer_resolution_z": 40,
+    }
 
 
 def info_url(
@@ -41,16 +44,19 @@ def info_url(
     return url_template.format_map(mapping)
 
 
-def mocked_caveclient(
+def CAVEclientMock(
     datastack_name=None,
     global_server=None,
     local_server=None,
     info_file=None,
     chunkedgraph=False,
-    chunkedgraph_server_version=None,
+    chunkedgraph_server_version="2.15.0",
     materialization=False,
-    materialization_server_version=None,
-    annotation=False,
+    materialization_server_version="4.30.1",
+    json_service=False,
+    json_service_server_version="0.7.0",
+    skeleton_service=False,
+    skeleton_service_server_version="0.3.8",
 ):
     if datastack_name is None:
         datastack_name = TEST_DATASTACK
@@ -59,14 +65,58 @@ def mocked_caveclient(
     if local_server is None:
         local_server = TEST_LOCAL_SERVER
     if info_file is None:
-        info_file = default_info
+        info_file = default_info(local_server)
 
     @responses.activate()
     def test_client():
-        responses.add(
-            info_url(datastack_name, global_server), json=info_file, status=200
-        )
+        url = info_url(datastack_name, global_server)
+        responses.add(responses.GET, url=url, json=info_file, status=200)
         client = CAVEclient(
             datastack_name, server_address=global_server, write_server_cache=False
         )
+        if chunkedgraph:
+            pcg_version_endpoint = endpoints.chunkedgraph_endpoints_common[
+                "get_version"
+            ]
+            pcg_mapping = {"cg_server_address": local_server}
+            version_url = pcg_version_endpoint.format_map(pcg_mapping)
+            responses.add(
+                responses.GET, version_url, json=chunkedgraph_server_version, status=200
+            )
+            client.chunkedgraph
+        if materialization:
+            mat_version_endpoint = endpoints.materialization_common["get_version"]
+            mat_mapping = {"me_server_address": local_server}
+            mat_version_url = mat_version_endpoint.format_map(mat_mapping)
+            responses.add(
+                responses.GET,
+                mat_version_url,
+                json=materialization_server_version,
+                status=200,
+            )
+            client.materialize
+        if json_service:
+            js_version_endpoint = endpoints.mat_version_endpoint["get_version"]
+            js_mapping = {"json_server_address": global_server}
+            js_version_url = js_version_endpoint.format_map(js_mapping)
+            responses.add(
+                responses.GET,
+                js_version_url,
+                json=json_service_server_version,
+                status=200,
+            )
+            client.state
+        if skeleton_service:
+            ss_version_endpoint = endpoints.skeletonservice_endpoints_v1["get_version"]
+            ss_mapping = {"skeleton_server_address": local_server}
+            ss_version_url = ss_version_endpoint.format_map(ss_mapping)
+            responses.add(
+                responses.GET,
+                ss_version_url,
+                json=skeleton_service_server_version,
+                status=200,
+            )
+            client.skeleton
         return client
+
+    return test_client

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -1,0 +1,75 @@
+from caveclient import endpoints, CAVEclient
+import os
+import numpy as np
+import pandas as pd
+
+try:
+    import pytest
+    import responses
+
+    imports_worked = True
+except ImportError:
+    imports_worked = False
+
+TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
+TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
+TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
+
+default_info = {
+    "viewer_site": "http://neuromancer-seung-import.appspot.com/",
+    "aligned_volume": {
+        "name": "test_volume",
+        "image_source": f"precomputed://https://{TEST_LOCAL_SERVER}/test-em/v1",
+        "id": 1,
+        "description": "This is a test only dataset.",
+    },
+    "synapse_table": "test_synapse_table",
+    "description": "This is the first test datastack. ",
+    "local_server": TEST_LOCAL_SERVER,
+    "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
+    "soma_table": "test_soma",
+    "analysis_database": None,
+    "viewer_resolution_x": 4.0,
+    "viewer_resolution_y": 4.0,
+    "viewer_resolution_z": 40,
+}
+
+
+def info_url(
+    datastack_name,
+    global_server,
+):
+    url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
+    mapping = {"i_server_address": global_server, "datastack_name": datastack_name}
+    return url_template.format_map(mapping)
+
+
+def mocked_caveclient(
+    datastack_name=None,
+    global_server=None,
+    local_server=None,
+    info_file=None,
+    chunkedgraph=False,
+    chunkedgraph_server_version=None,
+    materialization=False,
+    materialization_server_version=None,
+    annotation=False,
+):
+    if datastack_name is None:
+        datastack_name = TEST_DATASTACK
+    if global_server is None:
+        global_server = TEST_GLOBAL_SERVER
+    if local_server is None:
+        local_server = TEST_LOCAL_SERVER
+    if info_file is None:
+        info_file = default_info
+
+    @responses.activate()
+    def test_client():
+        responses.add(
+            info_url(datastack_name, global_server), json=info_file, status=200
+        )
+        client = CAVEclient(
+            datastack_name, server_address=global_server, write_server_cache=False
+        )
+        return client

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -1,21 +1,72 @@
 import os
+import warnings
+from typing import Optional
 from ..frameworkclient import CAVEclient
 from .. import endpoints
+
 
 try:
     import responses
 
     imports_worked = True
 except ImportError:
+    warnings.warn("Must install responses to use CAVEclientMock for testing")
     imports_worked = False
+
+DEFAULT_CHUNKEDGRAPH_SERVER_VERSION = "2.15.0"
+DEFAULT_MATERIALIZATION_SERVER_VERSON = "4.30.1"
+DEFAULT_SKELETON_SERVICE_SERVER_VERSION = "0.3.8"
+DEFAULT_JSON_SERVICE_SERVER_VERSION = "0.7.0"
 
 TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
 TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
 TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
-DEFAULT_MATERIALIZATION_VERSONS = [1, 2, 4, 8]
+DEFAULT_MATERIALIZATION_VERSONS = [1, 2]
 
 
-def default_info(local_server):
+def get_server_information(
+    datastack_name: str = TEST_DATASTACK,
+    global_server: str = TEST_GLOBAL_SERVER,
+    local_server: str = TEST_LOCAL_SERVER,
+) -> dict:
+    """Generate the datastack name and server locations used in testing.
+
+    Parameters
+    ----------
+    datastack_name : str, optional
+        Datastack value, by default the value in TEST_DATASTACK.
+    global_server : str, optional
+        Server for global services, by default TEST_GLOBAL_SERVER.
+    local_server : str, optional
+        Server for local services, by default TEST_LOCAL_SERVER.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: "datastack_name", "local_server", "global_server".
+    """
+    return {
+        "datastack_name": datastack_name,
+        "local_server": local_server,
+        "global_server": global_server,
+    }
+
+
+def default_info(
+    local_server: str = TEST_LOCAL_SERVER,
+) -> dict:
+    """Generate a info service info file for testing
+
+    Parameters
+    ----------
+    local_server : str, optional
+        Name of the local service, by default the value in TEST_LOCAL_SERVER.
+
+    Returns
+    -------
+    dict
+        Info file for the datastack.
+    """
     return {
         "viewer_site": "http://neuromancer-seung-import.appspot.com/",
         "aligned_volume": {
@@ -28,6 +79,7 @@ def default_info(local_server):
         "description": "This is the first test datastack.",
         "local_server": local_server,
         "segmentation_source": f"graphene://https://{local_server}/segmentation/table/test_v1",
+        "skeleton_source": f"precomputed://https://{local_server}/skeletoncache/api/v1/minnie65_phase3_v1/precomputed/skeleton/",
         "soma_table": "test_soma",
         "analysis_database": None,
         "viewer_resolution_x": 4.0,
@@ -37,15 +89,41 @@ def default_info(local_server):
 
 
 def info_url(
-    datastack_name,
-    global_server,
-):
+    datastack_name: str,
+    global_server: str,
+) -> str:
+    """Gets the info service URL for getting the info dictionary
+
+    Parameters
+    ----------
+    datastack_name : str
+        datastack_name
+    global_server : str
+        Global server address
+
+    Returns
+    -------
+    str
+        URL for the info service
+    """
+
     url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
     mapping = {"i_server_address": global_server, "datastack_name": datastack_name}
     return url_template.format_map(mapping)
 
 
+def version_url(
+    server_address: str,
+    endpoint_dictionary: dict,
+    service_key: str,
+) -> str:
+    version_endpoint = endpoint_dictionary["get_version"]
+    mapping = {service_key: server_address}
+    return version_endpoint.format_map(mapping)
+
+
 def get_table_name(info_file):
+    """Get the table name from the info file dictionary"""
     seg_source = info_file.get("segmentation_source")
     if seg_source:
         return seg_source.split("/")[-1]
@@ -54,24 +132,116 @@ def get_table_name(info_file):
 
 
 def CAVEclientMock(
-    datastack_name=None,
-    global_server=None,
-    local_server=None,
-    info_file=None,
-    chunkedgraph=False,
-    chunkedgraph_server_version="2.15.0",
-    materialization=False,
-    materialization_server_version="4.30.1",
-    available_materialization_versions=None,
-    json_service=False,
-    json_service_server_version="0.7.0",
-    skeleton_service=False,
-    skeleton_service_server_version="0.3.8",
-    l2cache=False,
+    datastack_name: Optional[str] = None,
+    global_server: Optional[str] = None,
+    local_server: Optional[str] = None,
+    info_file: Optional[dict] = None,
+    chunkedgraph: bool = False,
+    chunkedgraph_server_version: str = DEFAULT_CHUNKEDGRAPH_SERVER_VERSION,
+    materialization: bool = False,
+    materialization_server_version: str = DEFAULT_MATERIALIZATION_SERVER_VERSON,
+    available_materialization_versions: Optional[list] = None,
+    json_service: bool = False,
+    json_service_server_version: str = DEFAULT_JSON_SERVICE_SERVER_VERSION,
+    skeleton_service: bool = False,
+    skeleton_service_server_version: str = DEFAULT_SKELETON_SERVICE_SERVER_VERSION,
+    l2cache: bool = False,
+    l2cache_disabled: bool = False,
 ):
+    """Created a mocked CAVEclient function for testing using the responses library to mock
+    the server responses. This function returns a drop-in replacement for the `CAVEclient` function
+    that will be able to initialize itself and selected individual service clients with the selected options.
+
+    Note that the test configuration is intended to be purely for pytest purposes and should not
+    actually result in calls to active endpoints.
+
+    Parameters
+    ----------
+    datastack_name : str, optional
+        Name of the test datastack, by default None
+    global_server : str, optional
+        Test global server address, by default None
+    local_server : str, optional
+        Test local server address, by default None
+    info_file : dictionary, optional
+        Info service dictionary for the datastack, by default None
+    chunkedgraph : bool, optional
+        If True, configures the client to initialize a chunkedgraph subclient, by default False
+    chunkedgraph_server_version : str, optional
+        Sets the value of the chunkedgraph server version as a three-element semenatic version (e.g "2.3.4"),
+        by default the value in DEFAULT_CHUNKEDGRAPH_SERVER_VERSION.
+    materialization : bool, optional
+        If True, configures the client to initalize a materialization subclient, by default False
+        Note that materialization being set to True will also configure the chunkedgraph client.
+    materialization_server_version : str, optional
+        Sets the value of the materialization server version as a three-element semenatic version (e.g "2.3.4"),
+        by default the value in DEFAULT_MATERIALIZATION_SERVER_VERSON.
+    available_materialization_versions : list, optional
+        List of materialization database versions that the materialization client thinks exists, by default None.
+        If None, returns the value in DEFAULT_MATERIALIZATION_VERSONS.
+    json_service : bool, optional
+        If True, configures the client to initalize a materialization subclient, by default False
+    json_service_server_version : _type_, optional
+        Sets the value of the json state server version as a three-element semenatic version (e.g "2.3.4"),
+        by default the value in DEFAULT_JSON_SERVICE_SERVER_VERSION.
+    skeleton_service : bool, optional
+        If True, configures the client to initalize a skeleton service subclient, by default False
+    skeleton_service_server_version : _type_, optional
+        Sets the value of the skeleton service version as a three-element semenatic version (e.g "2.3.4"),
+        by default the value in DEFAULT_SKELETON_SERVICE_SERVER_VERSION.
+    l2cache : bool, optional
+        If True, configures the client to initialize an l2cache subclient, by default False
+        Note that l2cache being set to True will also configure the chunkedgraph client.
+    l2cache_disabled : bool, optional
+        If True, allows a subclient to be initialized, but emulates a situation without an L2 cache, by default False
+        Only used if l2cache is True.
+
+    Returns
+    -------
+    CAVEclient
+        A mocked and initialized CAVEclient object for testing
+
+    Examples
+    --------
+    To make a basic pytest fixture to test chunkedgraph features with an initialized CAVEclient object in your pytest conftest.py file:
+
+    ```python
+    import pytest
+    from caveclient.tools.testing import CAVEclientMock
+
+    test_datastack = "test_stack"
+    test_global_server = "https://test.cave.com"
+    test_local_server = "https://local.cave.com"
+
+    @pytest.fixture()
+    def test_client():
+        return CAVEclientMock(
+            datastack_name=test_datastack,
+            global_server=test_global_server,
+            local_server=test_local_server,
+            chunkedgraph=True,
+        )
+
+    You can also create more complex fixtures with multiple services initialized and specific server versions:
+
+    ```python
+    @pytest.fixture()
+    def fancier_test_client():
+        return CAVEclientMock(
+            datastack_name=test_datastack,
+            global_server=test_global_server,
+            local_server=test_local_server,
+            chunkedgraph=True,
+            chunkedgraph_server_version="3.0.2",
+            materialization=True,
+            materialization_server_version="4.21.4",
+            l2cache=True,
+        )
+    ```
+    """
     if not imports_worked:
         raise ImportError(
-            "Please install responses to use CAVEclientMock: 'pip install responses'}"
+            "Please install responses to use CAVEclientMock: e.g. 'pip install responses'}"
         )
 
     if datastack_name is None:
@@ -86,7 +256,7 @@ def CAVEclientMock(
         available_materialization_versions = DEFAULT_MATERIALIZATION_VERSONS
 
     @responses.activate()
-    def test_client():
+    def mockedCAVEclient():
         url = info_url(datastack_name, global_server)
         responses.add(responses.GET, url=url, json=info_file, status=200)
         client = CAVEclient(
@@ -94,22 +264,27 @@ def CAVEclientMock(
             server_address=global_server,
             write_server_cache=False,
             auth_token="just_a_test",
-            max_retries=0,
+            write_local_auth=False,
         )
-        if chunkedgraph or l2cache:
-            pcg_version_endpoint = endpoints.chunkedgraph_endpoints_common[
-                "get_version"
-            ]
-            pcg_mapping = {"cg_server_address": local_server}
-            version_url = pcg_version_endpoint.format_map(pcg_mapping)
+        if chunkedgraph or l2cache or materialization:
+            pcg_version_url = version_url(
+                local_server,
+                endpoints.chunkedgraph_endpoints_common,
+                "cg_server_address",
+            )
             responses.add(
-                responses.GET, version_url, json=chunkedgraph_server_version, status=200
+                responses.GET,
+                pcg_version_url,
+                json=chunkedgraph_server_version,
+                status=200,
             )
             client.chunkedgraph
         if materialization:
-            mat_version_endpoint = endpoints.materialization_common["get_version"]
-            mat_mapping = {"me_server_address": local_server}
-            mat_version_url = mat_version_endpoint.format_map(mat_mapping)
+            mat_version_url = version_url(
+                local_server,
+                endpoints.materialization_common,
+                "me_server_address",
+            )
             responses.add(
                 responses.GET,
                 mat_version_url,
@@ -131,9 +306,11 @@ def CAVEclientMock(
             )
             client.materialize
         if json_service:
-            js_version_endpoint = endpoints.mat_version_endpoint["get_version"]
-            js_mapping = {"json_server_address": global_server}
-            js_version_url = js_version_endpoint.format_map(js_mapping)
+            js_version_url = version_url(
+                global_server,
+                endpoints.jsonservice_endpoints_v1,
+                "json_server_address",
+            )
             responses.add(
                 responses.GET,
                 js_version_url,
@@ -142,9 +319,11 @@ def CAVEclientMock(
             )
             client.state
         if skeleton_service:
-            ss_version_endpoint = endpoints.skeletonservice_endpoints_v1["get_version"]
-            ss_mapping = {"skeleton_server_address": local_server}
-            ss_version_url = ss_version_endpoint.format_map(ss_mapping)
+            ss_version_url = version_url(
+                local_server,
+                endpoints.skeletonservice_endpoints_v1,
+                "skeleton_server_address",
+            )
             responses.add(
                 responses.GET,
                 ss_version_url,
@@ -161,15 +340,21 @@ def CAVEclientMock(
                 "table_id": client.chunkedgraph.table_name,
             }
             table_mapping_url = table_mapping_endpoint.format_map(l2_mapping)
-            print("table_mapping_url:", table_mapping_url)
-            responses.add(
-                responses.GET,
-                url=table_mapping_url,
-                json={client.chunkedgraph.table_name: "test_table"},
-                status=200,
-            )
-            print("has cache:", client.l2cache.has_cache())
+            if l2cache_disabled:
+                responses.add(
+                    responses.GET,
+                    url=table_mapping_url,
+                    json={},
+                    status=200,
+                )
+            else:
+                responses.add(
+                    responses.GET,
+                    url=table_mapping_url,
+                    json={client.chunkedgraph.table_name: "test_table"},
+                    status=200,
+                )
 
         return client
 
-    return test_client
+    return mockedCAVEclient()

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -1,10 +1,7 @@
-from caveclient import endpoints, CAVEclient
 import os
-import numpy as np
-import pandas as pd
+from caveclient import CAVEclient, endpoints
 
 try:
-    import pytest
     import responses
 
     imports_worked = True
@@ -24,7 +21,7 @@ default_info = {
         "description": "This is a test only dataset.",
     },
     "synapse_table": "test_synapse_table",
-    "description": "This is the first test datastack. ",
+    "description": "This is the first test datastack.",
     "local_server": TEST_LOCAL_SERVER,
     "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
     "soma_table": "test_soma",

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -120,6 +120,34 @@ def get_server_information(
     }
 
 
+def get_api_versions(
+    chunkedgraph_api_versions: list = CHUNKEDGRAPH_API_VERSIONS,
+    materialization_api_versions: list = MATERIALIZATION_API_VERSIONS,
+    schema_api_versions: list = SCHEMA_API_VERSIONS,
+):
+    """Get the API versions for the services used in testing.
+
+    Parameters
+    ----------
+    chunkedgraph_api_versions : list, optional
+        List of chunkedgraph API versions that the chunkedgraph client thinks exists, by default CHUNKEDGRAPH_API_VERSIONS.
+    materialization_api_versions : list, optional
+        List of materialization API versions that the materialization client thinks exists, by default MATERIALIZATION_API_VERSIONS.
+    schema_api_versions : list, optional
+        List of schema API versions that the schema client thinks exists, by default SCHEMA_API_VERSIONS.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: "chunkedgraph_api_versions", "materialization_api_versions", "schema_api_versions".
+    """
+    return {
+        "chunkedgraph_api_versions": chunkedgraph_api_versions,
+        "materialization_api_versions": materialization_api_versions,
+        "schema_api_versions": schema_api_versions,
+    }
+
+
 def default_info(
     local_server: str = TEST_LOCAL_SERVER,
 ) -> dict:
@@ -252,32 +280,38 @@ def CAVEclientMock(
     chunkedgraph : bool, optional
         If True, configures the client to initialize a chunkedgraph subclient, by default False
     chunkedgraph_server_version : str, optional
-        Sets the value of the chunkedgraph server version as a three-element semenatic version (e.g "2.3.4"),
+        Sets the value of the chunkedgraph server version as a three-element semanatic version (e.g "2.3.4"),
         by default the value in DEFAULT_CHUNKEDGRAPH_SERVER_VERSION.
+    chunkedgraph_api_versions : list, optional
+        List of chunkedgraph API versions that the chunkedgraph client thinks exists, by default None.
+        If None, returns the value in CHUNKEDGRAPH_API_VERSIONS.
     materialization : bool, optional
         If True, configures the client to initalize a materialization subclient, by default False
         Note that materialization being set to True will also configure the chunkedgraph client.
     materialization_server_version : str, optional
-        Sets the value of the materialization server version as a three-element semenatic version (e.g "2.3.4"),
+        Sets the value of the materialization server version as a three-element semanatic version (e.g "2.3.4"),
         by default the value in DEFAULT_MATERIALIZATION_SERVER_VERSON.
     available_materialization_versions : list, optional
         List of materialization database versions that the materialization client thinks exists, by default None.
         If None, returns the value in DEFAULT_MATERIALIZATION_VERSONS.
+    materialization_api_versions : list, optional
+        List of materialization API versions that the materialization client thinks exists, by default None.
+        If None, returns the value in MATERIALIZATION_API_VERSIONS.
     set_version: int, optional
         If set, will set the version of the materialization server to the value of set_version, by default None.
-        To work, this version must be in the list of available materialization veriosns.
+        To work, this version must be in the list of available materialization versions.
     set_version_metadata: dict, optional
         If set, will set the version metadata of the materialization server to the value of set_version_metadata.
         Default value is in DEFAULT_MATERIALIZATION_VERSION_METADATA.
     json_service : bool, optional
         If True, configures the client to initalize a materialization subclient, by default False
     json_service_server_version : _type_, optional
-        Sets the value of the json state server version as a three-element semenatic version (e.g "2.3.4"),
+        Sets the value of the json state server version as a three-element semanatic version (e.g "2.3.4"),
         by default the value in DEFAULT_JSON_SERVICE_SERVER_VERSION.
     skeleton_service : bool, optional
         If True, configures the client to initalize a skeleton service subclient, by default False
     skeleton_service_server_version : _type_, optional
-        Sets the value of the skeleton service version as a three-element semenatic version (e.g "2.3.4"),
+        Sets the value of the skeleton service version as a three-element semanatic version (e.g "2.3.4"),
         by default the value in DEFAULT_SKELETON_SERVICE_SERVER_VERSION.
     l2cache : bool, optional
         If True, configures the client to initialize an l2cache subclient, by default False
@@ -394,9 +428,6 @@ def CAVEclientMock(
                 json=chunkedgraph_api_versions,
                 status=200,
             )
-            pcg_endpoints = endpoints.chunkedgraph_api_versions[
-                max(chunkedgraph_api_versions)
-            ]
         if materialization:
             mat_api_url = api_version_url(
                 local_server,

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -511,7 +511,6 @@ def CAVEclientMock(
             server_address=global_server,
             write_server_cache=False,
             auth_token="just_a_test",
-            write_local_auth=False,
             global_only=global_only,
             version=set_version,
         )

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -1,10 +1,11 @@
 import os
 import warnings
-from packaging.version import Version
 from typing import Optional
-from ..frameworkclient import CAVEclient
-from .. import endpoints
 
+from packaging.version import Version
+
+from .. import endpoints
+from ..frameworkclient import CAVEclient
 
 try:
     import responses

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -1,0 +1,9 @@
+---
+title: caveclient.tools.testing
+---
+
+::: caveclient.tools.testing
+    options:
+        heading_level: 2
+        show_bases: false
+        members: ['CAVEclientMock', 'get_materialiation_info', 'get_server_versions', 'get_server_information', 'get_api_versions', 'default_info']

--- a/docs/tutorials/advanced.md
+++ b/docs/tutorials/advanced.md
@@ -30,3 +30,93 @@ client.get_session_defaults()
 
 More information on the available parameters can be found in the
 [API documentation](../api/config.md).
+
+## Writing unit tests using caveclient
+
+If you have a module that relies on caveclient and you want to write unit tests for it,
+you can use the `caveclient.testing` module to help you create an initialized, mocked
+client with user-specified options.
+This helps deal with the complex conversation that caveclient has with various services
+when initializing itself so that you get the appropriate functionality.
+The function `CAVEclientMock` offers a number of options for how to build a client,
+including server versions for various services, available API versions, and more.
+Importantly, the module provides sensible defaults but also allows you to override
+them as needed.
+Note that using testing requires the [responses](https://github.com/getsentry/responses)
+to be installed, which is not a dependency of caveclient.
+
+The `CAVEclientMock` function requires you to specify which services you expect to call on
+in order to ensure that your code is working as expected.
+For example, to create a pytest fixture that would utilize the `chunkedgraph` module,
+but otherwise use default nonsense test values, you could include this in your `conftest.py`:
+
+```python
+import pytest
+from caveclient.tools.testing import CAVEclientMock
+
+@pytest.fixture()
+def test_client():
+    return CAVEclientMock(
+        chunkedgraph=True,
+    )
+```
+
+Then, in your test module, you can use the `test_client` fixture to get a client.
+Note that after mocked initialization, the client will attempt normal network requests and
+thus you should mock the responses.
+If you only care to get a specific value back from a given function, you can use [pytest-mock](https://github.com/pytest-dev/pytest-mock/)
+to mock the response to a given function call.
+For example, if you have a function `do_something_with_roots` that takes a caveclient that uses the `get_roots` function,
+you could mock the `get_roots` function so that it return a specific value:
+
+```python
+from pytest_mock import mocker
+from conftest import test_client
+from my_module import do_something_with_roots
+
+def test_get_roots(mocker, test_client):
+    mocker.patch.object(test_client.chunkedgraph, 'get_roots', return_value=[1, 2, 3])
+    test_data = # Something appropriate
+    test_output = do_something_with_roots(test_client, test_data)
+    assert test_output == # The expected answer
+```
+
+### Specifying conditions
+
+While sensible defaults are provided, you can also specify things like server versions to make sure your code
+works with the versions of the services you expect.
+For example, let's make a richer mock client that specifies the server versions for the `chunkedgraph`, `materailization`,
+and `l2cache` services:
+
+```python
+@pytest.fixture()
+def version_specified_client():
+    return CAVEclientMock(
+        chunkedgraph=True,
+        chunkedgraph_server_version='3.0.1',
+        materialization=True,
+        materialization_server_version='2.0.0',
+        l2cache=True,
+    )
+```
+
+Note that some services like `l2cache` do not currently use a server version to offer different functionality, and this value
+is not exposed for them currently. See the API documentation for more information.
+
+You can also override default values like `server_address` or `datastack_name`:
+```python
+@pytest.fixture()
+def server_specified_client():
+    return CAVEclientMock(
+        datastack_name='my_datastack',
+        server_address='http://my.server.com',
+        chunkedgraph=True,
+        materialization=True,
+    )
+```
+
+If you want to get access to the various default values of server version, datastack name, datastack info file, and api versions,
+you can use functions `get_server_versions`, `get_server_information`, `default_info`, `get_api_versions` respectively.
+Each of these functions will return a dictionary of the values that can be used as a kwargs input into CAVEclientMock.
+If you specify your own override values, it will take precedence over the default value and you can just use the dictionary in your tests.
+See the caveclient tests for an example of how to use these functions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - General functions: 
       - api/config.md
       - api/datastack_lookup.md
+      - api/testing.md
   - Glossary: glossary.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,73 +3,25 @@ import os
 import pytest
 import responses
 
-from caveclient import CAVEclient, endpoints
+from caveclient.tools.testing import (
+    CAVEclientMock,
+    default_info,
+    get_server_information,
+)
 
-TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
-TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
-TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
 
-test_info = {
-    "viewer_site": "http://neuromancer-seung-import.appspot.com/",
-    "aligned_volume": {
-        "name": "test_volume",
-        "image_source": f"precomputed://https://{TEST_LOCAL_SERVER}/test-em/v1",
-        "id": 1,
-        "description": "This is a test only dataset.",
-    },
-    "synapse_table": "test_synapse_table",
-    "description": "This is the first test datastack. ",
-    "local_server": TEST_LOCAL_SERVER,
-    "segmentation_source": f"graphene://https://{TEST_LOCAL_SERVER}/segmentation/table/test_v1",
-    "soma_table": "test_soma",
-    "analysis_database": None,
-    "viewer_resolution_x": 4.0,
-    "viewer_resolution_y": 4.0,
-    "viewer_resolution_z": 40,
-}
-url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
-mapping = {"i_server_address": TEST_GLOBAL_SERVER, "datastack_name": TEST_DATASTACK}
-url = url_template.format_map(mapping)
+datastack_dict = get_server_information()
+test_info = default_info(datastack_dict["local_server"])
 
 
 @pytest.fixture()
-@responses.activate
 def myclient():
-    responses.add(responses.GET, url, json=test_info, status=200)
-
-    client = CAVEclient(
-        TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
-    )
-
-    # need to mock the response of the version checking code for each sub-client which
-    # wants that information, and then create the sub-client here since the mock is
-    # narrowly scoped to this function
-    version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/version"
-    responses.add(responses.GET, version_url, json="2.15.0", status=200)
-    client.chunkedgraph  # this will trigger the version check
-
-    mat_version_url = f"{TEST_LOCAL_SERVER}/materialize/version"
-    responses.add(responses.GET, mat_version_url, json="4.30.1", status=200)
-    client.materialize
-
-    return client
+    return CAVEclientMock(chunkedgraph=True, materialization=True, **datastack_dict)
 
 
 @pytest.fixture()
 @responses.activate
 def old_chunkedgraph_client():
-    responses.add(responses.GET, url, json=test_info, status=200)
-
-    client = CAVEclient(
-        TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
+    return CAVEclientMock(
+        chunkedgraph=True, chunkedgraph_server_version="1.0.0", **datastack_dict
     )
-
-    # need to mock the response of the version checking code for each sub-client which
-    # wants that information, and then create the sub-client here since the mock is
-    # narrowly scoped to this function
-    version_url = f"{TEST_LOCAL_SERVER}/segmentation/api/version"
-    responses.add(responses.GET, version_url, json="1.0.0", status=200)
-
-    client.chunkedgraph  # this will trigger the version check
-
-    return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,23 @@ from caveclient.tools.testing import (
 )
 
 
+# These are convenience functions to get a mix of specified and default values
 datastack_dict = get_server_information()
 server_versions = get_server_versions()
+
 test_info = default_info(datastack_dict["local_server"])
 
 
 @pytest.fixture()
 def myclient():
-    return CAVEclientMock(chunkedgraph=True, materialization=True, **datastack_dict)
+    return CAVEclientMock(
+        chunkedgraph=True,
+        materialization=True,
+        json_service=True,
+        skeleton_service=True,
+        l2cache=True,
+        **datastack_dict,
+    )
 
 
 @pytest.fixture()
@@ -31,4 +40,18 @@ def global_client():
         global_server=datastack_dict["global_server"],
         global_only=True,
         json_service=True,
+    )
+
+
+@pytest.fixture()
+def versioned_client():
+    return CAVEclientMock(
+        chunkedgraph=True,
+        materialization=True,
+        json_service=True,
+        skeleton_service=True,
+        l2cache=True,
+        available_materialization_versions=[1, 2, 3],
+        set_version=3,
+        **server_versions,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ from caveclient.tools.testing import (
     get_server_versions,
 )
 
-
-# These are convenience functions to get a mix of specified and default values
 datastack_dict = get_server_information()
 server_versions = get_server_versions()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,3 +55,13 @@ def version_specified_client():
         set_version=3,
         **server_versions,
     )
+
+
+@pytest.fixture()
+def mat_apiv2_specified_client():
+    return CAVEclientMock(
+        materialization=True,
+        available_materialization_versions=[1, 2, 3],
+        materialization_api_versions=[2],
+        **server_versions,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def global_client():
 
 
 @pytest.fixture()
-def versioned_client():
+def version_specified_client():
     return CAVEclientMock(
         chunkedgraph=True,
         materialization=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,15 @@
-import os
-
 import pytest
-import responses
 
 from caveclient.tools.testing import (
     CAVEclientMock,
     default_info,
     get_server_information,
+    get_server_versions,
 )
 
 
 datastack_dict = get_server_information()
+server_versions = get_server_versions()
 test_info = default_info(datastack_dict["local_server"])
 
 
@@ -20,8 +19,16 @@ def myclient():
 
 
 @pytest.fixture()
-@responses.activate
 def old_chunkedgraph_client():
     return CAVEclientMock(
         chunkedgraph=True, chunkedgraph_server_version="1.0.0", **datastack_dict
+    )
+
+
+@pytest.fixture()
+def global_client():
+    return CAVEclientMock(
+        global_server=datastack_dict["global_server"],
+        global_only=True,
+        json_service=True,
     )

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -7,7 +7,7 @@ import responses
 
 from caveclient.endpoints import annotation_endpoints_v2, schema_endpoints_v2
 
-from .conftest import TEST_DATASTACK, TEST_GLOBAL_SERVER, TEST_LOCAL_SERVER, test_info
+from .conftest import datastack_dict, test_info
 
 test_jsonschema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -57,9 +57,9 @@ test_jsonschema = {
 
 class TestAnnoClinet:
     default_mapping = {
-        "ae_server_address": TEST_LOCAL_SERVER,
-        "emas_server_address": TEST_GLOBAL_SERVER,
-        "datastack_name": TEST_DATASTACK,
+        "ae_server_address": datastack_dict["local_server"],
+        "emas_server_address": datastack_dict["global_server"],
+        "datastack_name": datastack_dict["datastack_name"],
         "aligned_volume_name": test_info.get("aligned_volume").get("name"),
         "table_name": "cell_type_test",
     }

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -14,7 +14,7 @@ from caveclient.endpoints import (
     chunkedgraph_endpoints_v1,
 )
 
-from .conftest import TEST_LOCAL_SERVER, test_info
+from .conftest import datastack_dict, test_info
 
 
 def binary_body_match(body):
@@ -39,7 +39,7 @@ def package_timestamp(timestamp, name="timestamp"):
 
 class TestChunkedgraph:
     _default_endpoint_map = {
-        "cg_server_address": TEST_LOCAL_SERVER,
+        "cg_server_address": datastack_dict["local_server"],
         "table_id": test_info["segmentation_source"].split("/")[-1],
     }
 
@@ -539,7 +539,9 @@ class TestChunkedgraph:
         assert qid_map == id_map
 
     def test_cloudvolume_path(self, myclient):
-        cvpath = f"graphene://{TEST_LOCAL_SERVER}/segmentation/api/v1/test_v1"
+        cvpath = (
+            f"graphene://{datastack_dict['local_server']}/segmentation/api/v1/test_v1"
+        )
         assert myclient.chunkedgraph.cloudvolume_path == cvpath
 
     @responses.activate

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -12,6 +12,7 @@ from .conftest import (
     server_versions,
     global_client,
     version_specified_client,
+    mat_apiv2_specified_client,
 )
 
 default_mapping = {
@@ -50,6 +51,10 @@ def test_versioned_client(version_specified_client):
     assert version_specified_client.timestamp == correct_date
     assert version_specified_client.materialize.version == 3
     assert version_specified_client.chunkedgraph.timestamp == correct_date
+
+
+def test_api_version(mat_apiv2_specified_client):
+    assert "api/v2" in mat_apiv2_specified_client.materialize._endpoints["simple_query"]
 
 
 class TestFrameworkClient:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -11,7 +11,7 @@ from .conftest import (
     datastack_dict,
     server_versions,
     global_client,
-    versioned_client,
+    version_specified_client,
 )
 
 default_mapping = {
@@ -42,14 +42,14 @@ def test_global_client(global_client):
     )
 
 
-def test_versioned_client(versioned_client):
+def test_versioned_client(version_specified_client):
     correct_date = datetime.datetime.strptime(
         "2024-06-05T10:10:01.203215", "%Y-%m-%dT%H:%M:%S.%f"
     ).replace(tzinfo=datetime.timezone.utc)
 
-    assert versioned_client.timestamp == correct_date
-    assert versioned_client.materialize.version == 3
-    assert versioned_client.chunkedgraph.timestamp == correct_date
+    assert version_specified_client.timestamp == correct_date
+    assert version_specified_client.materialize.version == 3
+    assert version_specified_client.chunkedgraph.timestamp == correct_date
 
 
 class TestFrameworkClient:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -11,6 +11,7 @@ from .conftest import (
     datastack_dict,
     server_versions,
     global_client,
+    versioned_client,
 )
 
 default_mapping = {
@@ -35,7 +36,20 @@ def test_global_client(global_client):
     assert global_client.info.datastack_name is None
     assert global_client.info.server_address == datastack_dict["global_server"]
     assert "Authorization" in global_client.auth.request_header
-    assert global_client.state.server_version == server_versions["json_service_version"]
+    assert (
+        global_client.state.server_version
+        == server_versions["json_service_server_version"]
+    )
+
+
+def test_versioned_client(versioned_client):
+    correct_date = datetime.datetime.strptime(
+        "2024-06-05T10:10:01.203215", "%Y-%m-%dT%H:%M:%S.%f"
+    ).replace(tzinfo=datetime.timezone.utc)
+
+    assert versioned_client.timestamp == correct_date
+    assert versioned_client.materialize.version == 3
+    assert versioned_client.chunkedgraph.timestamp == correct_date
 
 
 class TestFrameworkClient:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -7,12 +7,12 @@ from responses.matchers import query_param_matcher
 from caveclient import CAVEclient, endpoints, set_session_defaults
 
 from .conftest import (
-    test_info,
     datastack_dict,
-    server_versions,
     global_client,
-    version_specified_client,
     mat_apiv2_specified_client,
+    server_versions,
+    test_info,
+    version_specified_client,
 )
 
 default_mapping = {

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -6,29 +6,32 @@ from responses.matchers import query_param_matcher
 
 from caveclient import CAVEclient, endpoints, set_session_defaults
 
-from .conftest import TEST_DATASTACK, TEST_GLOBAL_SERVER, TEST_LOCAL_SERVER, test_info
+from .conftest import test_info, datastack_dict
 
 default_mapping = {
-    "me_server_address": TEST_LOCAL_SERVER,
-    "cg_server_address": TEST_LOCAL_SERVER,
+    "me_server_address": datastack_dict["local_server"],
+    "cg_server_address": datastack_dict["local_server"],
     "table_id": test_info["segmentation_source"].split("/")[-1],
-    "datastack_name": TEST_DATASTACK,
+    "datastack_name": datastack_dict["datastack_name"],
     "table_name": test_info["synapse_table"],
     "version": 1,
 }
 
 
 url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
-mapping = {"i_server_address": TEST_GLOBAL_SERVER, "datastack_name": TEST_DATASTACK}
+mapping = {
+    "i_server_address": datastack_dict["global_server"],
+    "datastack_name": datastack_dict["datastack_name"],
+}
 info_url = url_template.format_map(mapping)
 
 
 class TestFrameworkClient:
     default_mapping = {
-        "me_server_address": TEST_LOCAL_SERVER,
-        "cg_server_address": TEST_LOCAL_SERVER,
+        "me_server_address": datastack_dict["local_server"],
+        "cg_server_address": datastack_dict["local_server"],
         "table_id": test_info["segmentation_source"].split("/")[-1],
-        "datastack_name": TEST_DATASTACK,
+        "datastack_name": datastack_dict["datastack_name"],
         "table_name": test_info["synapse_table"],
         "version": 1,
     }
@@ -37,7 +40,9 @@ class TestFrameworkClient:
     def test_create_client(self):
         responses.add(responses.GET, info_url, json=test_info, status=200)
         _ = CAVEclient(
-            TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
+            datastack_dict["datastack_name"],
+            server_address=datastack_dict["global_server"],
+            write_server_cache=False,
         )
 
     @responses.activate
@@ -45,7 +50,7 @@ class TestFrameworkClient:
         responses.add(responses.GET, info_url, json=test_info, status=200)
 
         endpoint_mapping = self.default_mapping
-        endpoint_mapping["emas_server_address"] = TEST_GLOBAL_SERVER
+        endpoint_mapping["emas_server_address"] = datastack_dict["global_server"]
 
         api_versions_url = endpoints.chunkedgraph_endpoints_common[
             "get_api_versions"
@@ -98,15 +103,15 @@ class TestFrameworkClient:
 
         with assert_raises(ValueError):
             _ = CAVEclient(
-                TEST_DATASTACK,
-                server_address=TEST_GLOBAL_SERVER,
+                datastack_dict["datastack_name"],
+                server_address=datastack_dict["global_server"],
                 write_server_cache=False,
                 version=10,
             )
 
         versioned_client = CAVEclient(
-            TEST_DATASTACK,
-            server_address=TEST_GLOBAL_SERVER,
+            datastack_dict["datastack_name"],
+            server_address=datastack_dict["global_server"],
             write_server_cache=False,
             version=1,
         )
@@ -139,7 +144,9 @@ class TestFrameworkClient:
             status_forcelist=status_forcelist,
         )
         client = CAVEclient(
-            TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False
+            datastack_dict["datastack_name"],
+            server_address=datastack_dict["global_server"],
+            write_server_cache=False,
         )
         assert client.l2cache.session.adapters["https://"]._pool_maxsize == pool_maxsize
         assert client.l2cache.session.adapters["https://"]._pool_block

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -8,11 +8,11 @@ from caveclient import CAVEclient, endpoints, set_session_defaults
 
 from .conftest import (
     datastack_dict,
-    global_client,
-    mat_apiv2_specified_client,
+    global_client,  # noqa: F401
+    mat_apiv2_specified_client,  # noqa: F401
     server_versions,
     test_info,
-    version_specified_client,
+    version_specified_client,  # noqa: F401
 )
 
 default_mapping = {
@@ -33,7 +33,7 @@ mapping = {
 info_url = url_template.format_map(mapping)
 
 
-def test_global_client(global_client):
+def test_global_client(global_client):  # noqa: F811
     assert global_client.info.datastack_name is None
     assert global_client.info.server_address == datastack_dict["global_server"]
     assert "Authorization" in global_client.auth.request_header
@@ -43,7 +43,7 @@ def test_global_client(global_client):
     )
 
 
-def test_versioned_client(version_specified_client):
+def test_versioned_client(version_specified_client):  # noqa: F811
     correct_date = datetime.datetime.strptime(
         "2024-06-05T10:10:01.203215", "%Y-%m-%dT%H:%M:%S.%f"
     ).replace(tzinfo=datetime.timezone.utc)
@@ -53,7 +53,7 @@ def test_versioned_client(version_specified_client):
     assert version_specified_client.chunkedgraph.timestamp == correct_date
 
 
-def test_api_version(mat_apiv2_specified_client):
+def test_api_version(mat_apiv2_specified_client):  # noqa: F811
     assert "api/v2" in mat_apiv2_specified_client.materialize._endpoints["simple_query"]
 
 

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -6,7 +6,12 @@ from responses.matchers import query_param_matcher
 
 from caveclient import CAVEclient, endpoints, set_session_defaults
 
-from .conftest import test_info, datastack_dict
+from .conftest import (
+    test_info,
+    datastack_dict,
+    server_versions,
+    global_client,
+)
 
 default_mapping = {
     "me_server_address": datastack_dict["local_server"],
@@ -24,6 +29,13 @@ mapping = {
     "datastack_name": datastack_dict["datastack_name"],
 }
 info_url = url_template.format_map(mapping)
+
+
+def test_global_client(global_client):
+    assert global_client.info.datastack_name is None
+    assert global_client.info.server_address == datastack_dict["global_server"]
+    assert "Authorization" in global_client.auth.request_header
+    assert global_client.state.server_version == server_versions["json_service_version"]
 
 
 class TestFrameworkClient:

--- a/tests/test_infoservice.py
+++ b/tests/test_infoservice.py
@@ -3,7 +3,7 @@ import responses
 
 from caveclient.endpoints import infoservice_endpoints_v2
 
-from .conftest import TEST_DATASTACK, TEST_GLOBAL_SERVER, test_info
+from .conftest import test_info, datastack_dict
 
 
 def test_info_d(myclient):
@@ -13,8 +13,8 @@ def test_info_d(myclient):
 
 class TestInfoClient:
     default_mapping = {
-        "datastack_name": TEST_DATASTACK,
-        "i_server_address": TEST_GLOBAL_SERVER,
+        "datastack_name": datastack_dict["datastack_name"],
+        "i_server_address": datastack_dict["global_server"],
     }
     endpoints = infoservice_endpoints_v2
 

--- a/tests/test_infoservice.py
+++ b/tests/test_infoservice.py
@@ -3,7 +3,7 @@ import responses
 
 from caveclient.endpoints import infoservice_endpoints_v2
 
-from .conftest import test_info, datastack_dict
+from .conftest import datastack_dict, test_info
 
 
 def test_info_d(myclient):

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -19,7 +19,7 @@ from caveclient.endpoints import (
     schema_endpoints_v2,
 )
 
-from .conftest import test_info, datastack_dict
+from .conftest import datastack_dict, test_info
 
 
 def test_info_d(myclient):

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -19,7 +19,7 @@ from caveclient.endpoints import (
     schema_endpoints_v2,
 )
 
-from .conftest import TEST_DATASTACK, TEST_GLOBAL_SERVER, TEST_LOCAL_SERVER, test_info
+from .conftest import test_info, datastack_dict
 
 
 def test_info_d(myclient):
@@ -49,10 +49,10 @@ def serialize_dataframe(df, compression="zstd"):
 
 class TestMatclient:
     default_mapping = {
-        "me_server_address": TEST_LOCAL_SERVER,
-        "cg_server_address": TEST_LOCAL_SERVER,
+        "me_server_address": datastack_dict["local_server"],
+        "cg_server_address": datastack_dict["local_server"],
         "table_id": test_info["segmentation_source"].split("/")[-1],
-        "datastack_name": TEST_DATASTACK,
+        "datastack_name": datastack_dict["datastack_name"],
         "table_name": test_info["synapse_table"],
         "version": 1,
     }
@@ -322,7 +322,7 @@ class TestMatclient:
         myclient = copy.deepcopy(myclient)
         myclient._materialize = None
         endpoint_mapping = self.default_mapping
-        endpoint_mapping["emas_server_address"] = TEST_GLOBAL_SERVER
+        endpoint_mapping["emas_server_address"] = datastack_dict["global_server"]
 
         mat_version_url = materialization_common["get_version"].format_map(
             endpoint_mapping

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -56,7 +56,7 @@ class TestMatclient:
         "table_name": test_info["synapse_table"],
         "version": 1,
     }
-    endpoints = materialization_endpoints_v2
+    endpoints = materialization_endpoints_v3
 
     table_metadata = {
         "aligned_volume": "minnie65_phase3",

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -14,7 +14,6 @@ from caveclient import materializationengine
 from caveclient.endpoints import (
     chunkedgraph_endpoints_common,
     materialization_common,
-    materialization_endpoints_v2,
     materialization_endpoints_v3,
     schema_endpoints_v2,
 )


### PR DESCRIPTION
Adding a small submodule `caveclient.tools.testing` that makes it much easier to mock CAVEclients for testing.

1) CAVEclientMock lets you specify which services you anticipate loading, can take a datastack or use a only global-only version, can select what versions of each service you want to test against, specify api version availability, set materialization versions, etc. In general, CAVEclient initialization options are mocked out.

2) CAVEclient conftest.py was altered to use this tooling and several small tests were added to use these features.

3) This caught one or two bugs/issues thanks to these new tests.