### PR TITLE
Add a `get_l2data_table` method to level2 cache

### DIFF
--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -1,7 +1,11 @@
 import json
+import time
+from typing import Optional, Union
 from urllib.parse import urlparse
 from warnings import warn
 
+import numpy as np
+import pandas as pd
 from requests.exceptions import HTTPError
 
 from .auth import AuthClient
@@ -12,6 +16,53 @@ from .endpoints import (
 )
 
 SERVER_KEY = "l2cache_server_address"
+
+
+def _flatten_rep_coord(x):
+    if isinstance(x, float):
+        x = np.empty(3)
+    return pd.Series(x, index=["rep_coord_nm_x", "rep_coord_nm_y", "rep_coord_nm_z"])
+
+
+def _flatten_pca(x):
+    if isinstance(x, float):
+        x = np.empty((3, 3))
+    return pd.Series(
+        np.array(x).flatten(),
+        index=[
+            "pca_0_x",
+            "pca_0_y",
+            "pca_0_z",
+            "pca_1_x",
+            "pca_1_y",
+            "pca_1_z",
+            "pca_2_x",
+            "pca_2_y",
+            "pca_2_z",
+        ],
+    )
+
+
+def _flatten_pca_val(x):
+    if isinstance(x, float):
+        x = np.empty(3)
+    return pd.Series(x, index=["pca_val_0", "pca_val_1", "pca_val_2"])
+
+
+def _flatten_chunk_intersect_count(x):
+    if isinstance(x, float):
+        x = np.empty((2, 3))
+    return pd.Series(
+        np.array(x).flatten(),
+        index=[
+            "chunk_intersect_count_x_bottom",
+            "chunk_intersect_count_y_bottom",
+            "chunk_intersect_count_z_bottom",
+            "chunk_intersect_count_x_top",
+            "chunk_intersect_count_y_top",
+            "chunk_intersect_count_z_top",
+        ],
+    )
 
 
 class L2CacheClient(ClientBase):
@@ -60,22 +111,35 @@ class L2CacheClient(ClientBase):
     def default_url_mapping(self):
         return self._default_url_mapping.copy()
 
-    def get_l2data(self, l2_ids, attributes=None):
+    def get_l2data(
+        self, l2_ids: Union[list, np.ndarray], attributes: Optional[list] = None
+    ) -> dict:
         """
         Gets the attributed statistics data for L2 ids.
 
         Parameters
         ----------
         l2_ids : list or np.ndarray
-            a list of level 2 ids
+            A list of level 2 ids.
         attributes : list, optional
-            a list of attributes to retrieve. Defaults to None which will return all that are available.
-            Available stats are ['area_nm2', 'chunk_intersect_count', 'max_dt_nm', 'mean_dt_nm', 'pca', 'pca_val', 'rep_coord_nm', 'size_nm3']. See docs for more description.
+            A list of attributes to retrieve. Defaults to `None`, which will return all
+            that are available. Available stats are:
+
+            - `area_nm2`
+            - `chunk_intersect_count`
+            - `max_dt_nm`
+            - `mean_dt_nm`
+            - `pca`
+            - `pca_val`
+            - `rep_coord_nm`
+            - `size_nm3`
+
+            See [the tutorial](../../tutorials/l2cache) for more description.
 
         Returns
         -------
         dict
-            keys are l2 ids, values are data
+            Keys are l2 ids, values are data.
         """
 
         query_d = {"int64_as_str": False}
@@ -95,6 +159,70 @@ class L2CacheClient(ClientBase):
             params=query_d,
         )
         return handle_response(response)
+
+    def get_l2data_table(
+        self,
+        l2_ids: Union[list, np.ndarray],
+        attributes: Optional[list] = None,
+        split_columns: bool = True,
+    ) -> pd.DataFrame:
+        """
+        Gets the attributed statistics data for L2 ids, returned as a dataframe.
+
+        Parameters
+        ----------
+        l2_ids : list or np.ndarray
+            A list of level 2 ids.
+        attributes : list, optional
+            A list of attributes to retrieve. Defaults to `None`, which will return all
+            that are available. Available stats are:
+
+            - `area_nm2`
+            - `chunk_intersect_count`
+            - `max_dt_nm`
+            - `mean_dt_nm`
+            - `pca`
+            - `pca_val`
+            - `rep_coord_nm`
+            - `size_nm3`
+
+            See [the tutorial](../../tutorials/l2cache) for more description.
+
+        split_columns : bool, optional
+            Whether to split columns with multiple values into separate columns.
+
+        Returns
+        -------
+        :
+            A pandas dataframe with the requested attributes as columns and indexed by l2_id.
+        """
+
+        data = self.get_l2data(l2_ids, attributes=attributes)
+        df = pd.DataFrame(data).T
+        df.index.name = "l2_id"
+        df.index = df.index.astype(int)
+
+        if split_columns:
+            append = pd.DataFrame(index=df.index)
+            if "rep_coord_nm" in df.columns:
+                append = append.join(df["rep_coord_nm"].apply(_flatten_rep_coord))
+            if "pca" in df.columns:
+                append = append.join(df["pca"].apply(_flatten_pca))
+            if "pca_val" in df.columns:
+                append = append.join(df["pca_val"].apply(_flatten_pca_val))
+            if "chunk_intersect_count" in df.columns:
+                append = append.join(
+                    df["chunk_intersect_count"].apply(_flatten_chunk_intersect_count)
+                )
+            df = df.join(append)
+            df.drop(
+                columns=df.columns.intersection(
+                    ["rep_coord_nm", "pca", "pca_val" "chunk_intersect_count"]
+                ),
+                inplace=True,
+            )
+
+        return df
 
     def cache_metadata(self):
         """Retrieves the meta data for the cache

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -1,5 +1,4 @@
 import json
-import time
 from typing import Optional, Union
 from urllib.parse import urlparse
 from warnings import warn


### PR DESCRIPTION
- adds a method which returns a dataframe instead of a dict
- option to split columns, true by default but up for debate
- also fixed up the docs a bit