### PR TITLE
Allow get_state_json to accept direct URLs

### DIFF
--- a/caveclient/jsonservice.py
+++ b/caveclient/jsonservice.py
@@ -197,7 +197,7 @@ class JSONService(ClientBase):
         self,
         json_state: dict,
         state_id: Optional[int] = None,
-        timestamp: Optional["datetime.datetime"] = None,
+        timestamp: Optional["time.time"] = None,  # noqa: F821
     ) -> int:
         """Upload a Neuroglancer JSON state
 

--- a/tests/test_jsonclient.py
+++ b/tests/test_jsonclient.py
@@ -1,0 +1,23 @@
+import responses
+
+from .conftest import datastack_dict
+
+
+@responses.activate()
+def test_basic_state(myclient):
+    global_server = datastack_dict["global_server"]
+    state_id = 1234
+    url = f"{global_server}/nglstate/api/v1/{state_id}"
+    responses.add(responses.GET, url=url, json={"layers": ["img", "seg"]}, status=200)
+    state = myclient.state.get_state_json(state_id)
+    assert "img" in state["layers"]
+
+    direct_url = "https://my-fake-url.com/direct_state.json"
+    responses.add(
+        responses.GET,
+        url=direct_url,
+        json={"layers": ["direct_img", "direct_seg"]},
+        status=200,
+    )
+    state = myclient.state.get_state_json(direct_url)
+    assert "direct_seg" in state["layers"]


### PR DESCRIPTION
## Adding

* `client.state.get_state_json` can now accept a url string directly, which bypasses the endpoints.
* `spelunker` is a valid name for google-style neuroglancer.

## Backend

* Added basic tests for jsonstate getting state json
* Type hinting for state client functions