### PR TITLE
add tables.find and views.find

### DIFF
--- a/caveclient/tools/table_manager.py
+++ b/caveclient/tools/table_manager.py
@@ -983,6 +983,21 @@ class TableManager(object):
     def table_names(self):
         return self._tables
 
+    def find(self, search_str):
+        """Find tables that contain a string
+
+        Parameters
+        ----------
+        search_str : str
+
+
+        Returns
+        -------
+        list
+            Table names with that string
+        """
+        return [tn for tn in self.table_names if search_str in tn]
+
     def __len__(self):
         return len(self._tables)
 
@@ -1016,6 +1031,21 @@ class ViewManager(object):
     @property
     def table_names(self):
         return self._views
+
+    def find(self, search_str):
+        """Find tables that contain a string
+
+        Parameters
+        ----------
+        search_str : str
+
+
+        Returns
+        -------
+        list
+            Table names with that string
+        """
+        return [tn for tn in self.table_names if search_str in tn]
 
     def __len__(self):
         return len(self._views)

--- a/caveclient/tools/table_manager.py
+++ b/caveclient/tools/table_manager.py
@@ -984,7 +984,7 @@ class TableManager(object):
         return self._tables
 
     def find(self, search_str):
-        """Find tables that contain a string
+        """Find tables that contain a string. Case is ignored.
 
         Parameters
         ----------
@@ -996,7 +996,7 @@ class TableManager(object):
         list
             Table names with that string
         """
-        return [tn for tn in self.table_names if search_str in tn]
+        return [tn for tn in self.table_names if search_str.lower() in tn.lower()]
 
     def __len__(self):
         return len(self._tables)
@@ -1033,7 +1033,7 @@ class ViewManager(object):
         return self._views
 
     def find(self, search_str):
-        """Find tables that contain a string
+        """Find tables that contain a string. Case is ignored.
 
         Parameters
         ----------
@@ -1045,7 +1045,7 @@ class ViewManager(object):
         list
             Table names with that string
         """
-        return [tn for tn in self.table_names if search_str in tn]
+        return [tn for tn in self.table_names if search_str.lower() in tn.lower()]
 
     def __len__(self):
         return len(self._views)

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -387,6 +387,9 @@ class TestMatclient:
         )
         print(len(myclient.materialize.tables))
         assert len(myclient.materialize.tables) == 2
+
+        assert myclient.materialize.tables.find("column")[0] == "allen_column_mtypes_v2"
+
         qry = myclient.materialize.tables.allen_column_mtypes_v2(
             pt_root_id=[123, 456], target_id=271700
         )
@@ -396,6 +399,8 @@ class TestMatclient:
         assert "allen_column_mtypes_v2" == qry.joins_kwargs.get("joins")[0][0]
 
         assert "single_neurons" in myclient.materialize.views
+        assert myclient.materialize.views.find("single")[0] == "single_neurons"
+
         vqry = myclient.materialize.views.single_neurons(pt_root_id=[123, 456])
         assert 123 in vqry.filter_kwargs_mat.get("filter_in_dict").get("pt_root_id")
 


### PR DESCRIPTION
Very small feature addition:

`client.materialize.tables` and `client.materialize.views` get a new function `find` that lets you search for a string in the list of table names. Very simple, no fuzzy 

So for example, `client.materialize.tables.find("syn")` would give a list of any tables that have `syn` in their name.