### PR TITLE
Add imagery mirrors to the info file

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import json
 import logging
@@ -114,7 +115,7 @@ https://caveconnectome.github.io/CAVEclient/tutorials/authentication/
 or follow instructions under 
 client.auth.get_new_token() for how to set a valid API token.
 after initializing a global client with
-client=CAVEclient(server_address="{urlp.scheme +"://"+ urlp.netloc}")"""
+client=CAVEclient(server_address="{urlp.scheme + "://" + urlp.netloc}")"""
         )
 
 
@@ -221,7 +222,7 @@ class ClientBase(object):
 
     @property
     def default_url_mapping(self):
-        return self._default_url_mapping
+        return copy.copy(self._default_url_mapping)
 
     @property
     def server_address(self):
@@ -322,6 +323,7 @@ class ClientBaseWithDatastack(ClientBase):
             over_client=over_client,
         )
         self._datastack_name = datastack_name
+        self._default_url_mapping["datastack_name"] = self._datastack_name
 
     @property
     def datastack_name(self):

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -122,6 +122,7 @@ infoservice_endpoints_v2 = {
     "datastacks_from_aligned_volume": info_v2
     + "/aligned_volume/{aligned_volume_name}/datastacks",
     "image_sources": info_v2 + "/datastack/{datastack_name}/image_sources",
+    "get_version": info_v2 + "/version",
 }
 
 infoservice_api_versions = {1: infoservice_endpoints_v1, 2: infoservice_endpoints_v2}

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -121,6 +121,7 @@ infoservice_endpoints_v2 = {
     "datastack_info": info_v2 + "/datastack/full/{datastack_name}",
     "datastacks_from_aligned_volume": info_v2
     + "/aligned_volume/{aligned_volume_name}/datastacks",
+    "image_sources": info_v2 + "/datastack/{datastack_name}/image_sources",
 }
 
 infoservice_api_versions = {1: infoservice_endpoints_v1, 2: infoservice_endpoints_v2}

--- a/caveclient/format_utils.py
+++ b/caveclient/format_utils.py
@@ -59,6 +59,8 @@ def format_cloudvolume(objurl):
         return format_graphene(objurl)
     elif qry.scheme == "gs" or qry.scheme == "http" or qry.scheme == "https":
         return format_precomputed_https(objurl)
+    elif qry.scheme == "precomputed":
+        return objurl
     else:
         return None
 
@@ -85,4 +87,5 @@ output_map = {
     "neuroglancer": format_neuroglancer,
     "cave_explorer": format_cave_explorer,
     "cave-explorer": format_cave_explorer,
+    "spelunker": format_cave_explorer,
 }

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -547,7 +547,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
     @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
     def image_cloudvolume(
         self, image_mirror: Optional[str] = None, **kwargs
-    ) -> "cloudvolume.CloudVolume":
+    ) -> "cloudvolume.CloudVolume":  # noqa: F821
         """Generate a cloudvolume instance based on the image source, using authentication if needed and
         sensible default values for reading CAVE resources. By default, fill_missing is True and bounded
         is False. All keyword arguments are passed onto the CloudVolume initialization function, and defaults
@@ -563,7 +563,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
     #
     def segmentation_cloudvolume(
         self, use_client_secret=True, **kwargs
-    ) -> "cloudvolume.CloudVolume":
+    ) -> "cloudvolume.CloudVolume":  # noqa: F821
         """Generate a cloudvolume instance based on the segmentation source, using authentication if needed and
         sensible default values for reading CAVE resources. By default, fill_missing is True and bounded
         is False. All keyword arguments are passed onto the CloudVolume initialization function, and defaults

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -172,6 +172,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
     def get_aligned_volume_info(
         self,
         datastack_name: Optional[str] = None,
@@ -386,7 +387,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
-    # @_check_version_compatibility(method_constraint=">=4.3.0")
+    @_check_version_compatibility(method_constraint=">=4.3.0")
     def get_image_mirror_names(
         self,
         datastack_name: Optional[str] = None,
@@ -540,6 +541,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
             use_stored=use_stored,
         )
 
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
     def image_cloudvolume(
         self, image_mirror: Optional[str] = None, **kwargs
     ) -> "cloudvolume.CloudVolume":

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -1,13 +1,14 @@
 import re
 from typing import Literal, Optional
+
 import numpy as np
 
 from .auth import AuthClient
 from .base import (
     ClientBaseWithDatastack,
     _api_endpoints,
-    handle_response,
     _check_version_compatibility,
+    handle_response,
 )
 from .endpoints import (
     default_global_server_address,

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -175,7 +175,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
-    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.1"})
     def get_aligned_volume_info(
         self,
         datastack_name: Optional[str] = None,
@@ -366,7 +366,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         )
         return output_map.get(format_for)(av_info["image_source"])
 
-    @_check_version_compatibility(method_constraint=">=4.3.0")
+    @_check_version_compatibility(method_constraint=">=4.3.1")
     def get_image_mirrors(self, datastack_name: Optional[str] = None) -> list:
         """Get all image sources for a given aligned volume
 
@@ -390,7 +390,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
-    @_check_version_compatibility(method_constraint=">=4.3.0")
+    @_check_version_compatibility(method_constraint=">=4.3.1")
     def get_image_mirror_names(
         self,
         datastack_name: Optional[str] = None,
@@ -544,7 +544,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
             use_stored=use_stored,
         )
 
-    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.1"})
     def image_cloudvolume(
         self, image_mirror: Optional[str] = None, **kwargs
     ) -> "cloudvolume.CloudVolume":  # noqa: F821

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -103,7 +103,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
-    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.1"})
     def get_datastack_info(
         self,
         datastack_name: Optional[str] = None,
@@ -119,7 +119,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         use_stored : bool, optional
             If True and the information has already been queried for that datastack, then uses the cached version. If False, re-queries the infromation. By default True
         image_mirror : str, optional
-            If not None, will use this image mirror to get the datastack info. By default None. Requires info service app version >= 4.3.0.
+            If not None, will use this image mirror to get the datastack info. By default None. Requires info service app version >= 4.3.1.
             Note that getting the datastack info with a specific image mirror will overwrite the cached info.
             Use `refresh_stored_data` to reload the datastack info with the default values.
 

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -118,7 +118,9 @@ class InfoServiceClient(ClientBaseWithDatastack):
         use_stored : bool, optional
             If True and the information has already been queried for that datastack, then uses the cached version. If False, re-queries the infromation. By default True
         image_mirror : str, optional
-            If not None, will use this image mirror to get the datastack info. By default None. Requires info service app version >= 4.3.0
+            If not None, will use this image mirror to get the datastack info. By default None. Requires info service app version >= 4.3.0.
+            Note that getting the datastack info with a specific image mirror will overwrite the cached info.
+            Use `refresh_stored_data` to reload the datastack info with the default values.
 
         Returns
         -------

--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -102,7 +102,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         response = self.session.get(url)
         return handle_response(response)
 
-    # @_check_version_compatibility(kwarg_use_constraints={"image_source": ">=4.3.0"})
+    @_check_version_compatibility(kwarg_use_constraints={"image_mirror": ">=4.3.0"})
     def get_datastack_info(
         self,
         datastack_name: Optional[str] = None,
@@ -118,7 +118,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         use_stored : bool, optional
             If True and the information has already been queried for that datastack, then uses the cached version. If False, re-queries the infromation. By default True
         image_mirror : str, optional
-            If not None, will use this image mirror to get the datastack info. By default None
+            If not None, will use this image mirror to get the datastack info. By default None. Requires info service app version >= 4.3.0
 
         Returns
         -------
@@ -362,7 +362,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
         )
         return output_map.get(format_for)(av_info["image_source"])
 
-    # @_check_version_compatibility(method_constraint=">=4.3.0")
+    @_check_version_compatibility(method_constraint=">=4.3.0")
     def get_image_mirrors(self, datastack_name: Optional[str] = None) -> list:
         """Get all image sources for a given aligned volume
 
@@ -555,6 +555,7 @@ class InfoServiceClient(ClientBaseWithDatastack):
             **kwargs,
         )
 
+    #
     def segmentation_cloudvolume(
         self, use_client_secret=True, **kwargs
     ) -> "cloudvolume.CloudVolume":

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -16,10 +16,12 @@ except ImportError:
     warnings.warn("Must install responses to use CAVEclientMock for testing")
     imports_worked = False
 
-DEFAULT_CHUNKEDGRAPH_SERVER_VERSION = "2.18.0"
-DEFAULT_MATERIALIZATION_SERVER_VERSON = "4.30.1"
+DEFAULT_CHUNKEDGRAPH_SERVER_VERSION = "999.0.0"
+DEFAULT_MATERIALIZATION_SERVER_VERSON = "999.0.0"
 DEFAULT_SKELETON_SERVICE_SERVER_VERSION = "999.0.0"  # Individual tests might confirm the ability to adapt to old versions by mocking older versions, but make the default test behavior assumes an up-to-date system.
-DEFAULT_JSON_SERVICE_SERVER_VERSION = "0.7.0"
+DEFAULT_JSON_SERVICE_SERVER_VERSION = "999.0.0"
+DEFAULT_INFO_SERVER_VERSION = "999.0.0"
+
 
 TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
 TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
@@ -259,6 +261,7 @@ def CAVEclientMock(
     schema_api_versions: Optional[list] = None,
     l2cache: bool = False,
     l2cache_disabled: bool = False,
+    info_server_version: str = DEFAULT_INFO_SERVER_VERSION,
     global_only: bool = False,
 ):
     """Created a mocked CAVEclient function for testing using the responses library to mock
@@ -402,6 +405,15 @@ def CAVEclientMock(
 
     @responses.activate()
     def mockedCAVEclient():
+        info_version_url = version_url(
+            global_server, endpoints.infoservice_endpoints_v2, "i_server_address"
+        )
+        responses.add(
+            responses.GET,
+            url=info_version_url,
+            json=str(info_server_version),
+            status=200,
+        )
         url = info_url(datastack_name, global_server)
         responses.add(responses.GET, url=url, json=info_file, status=200)
 

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -16,12 +16,12 @@ except ImportError:
     warnings.warn("Must install responses to use CAVEclientMock for testing")
     imports_worked = False
 
-DEFAULT_CHUNKEDGRAPH_SERVER_VERSION = "999.0.0"
+
+DEFAULT_CHUNKEDGRAPH_SERVER_VERSION = "2.999.0"
 DEFAULT_MATERIALIZATION_SERVER_VERSON = "999.0.0"
 DEFAULT_SKELETON_SERVICE_SERVER_VERSION = "999.0.0"  # Individual tests might confirm the ability to adapt to old versions by mocking older versions, but make the default test behavior assumes an up-to-date system.
 DEFAULT_JSON_SERVICE_SERVER_VERSION = "999.0.0"
 DEFAULT_INFO_SERVER_VERSION = "999.0.0"
-
 
 TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
 TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
@@ -67,6 +67,7 @@ def get_server_versions(
     materialization_version: str = DEFAULT_MATERIALIZATION_SERVER_VERSON,
     skeleton_service_version: str = DEFAULT_SKELETON_SERVICE_SERVER_VERSION,
     json_service_version: str = DEFAULT_JSON_SERVICE_SERVER_VERSION,
+    info_server_version: str = DEFAULT_INFO_SERVER_VERSION,
 ) -> dict:
     """Get the server versions for the services used in testing.
 
@@ -92,6 +93,7 @@ def get_server_versions(
         "materialization_server_version": Version(materialization_version),
         "skeleton_service_server_version": Version(skeleton_service_version),
         "json_service_server_version": Version(json_service_version),
+        "info_server_version": Version(info_server_version),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,40 @@ from caveclient.tools.testing import (
     default_info,
     get_server_information,
     get_server_versions,
+    TEST_LOCAL_SERVER,
 )
 
 datastack_dict = get_server_information()
 server_versions = get_server_versions()
 
 test_info = default_info(datastack_dict["local_server"])
+
+
+def mirror_info(
+    local_server: str = TEST_LOCAL_SERVER,
+):
+    info = default_info(local_server)
+    info["aligned_volume"] = image_mirrors(local_server)[1]
+    return info
+
+
+def image_mirrors(
+    local_server: str = TEST_LOCAL_SERVER,
+):
+    return [
+        {
+            "name": "test_volume",
+            "image_source": f"precomputed://https://{local_server}/test-em/v1",
+            "id": 1,
+            "description": "This is a test only dataset.",
+        },
+        {
+            "name": "test_volume_mirror",
+            "image_source": f"precomputed://https://{local_server}/test-em/mirror",
+            "id": 2,
+            "description": "This is a test mirror dataset.",
+        },
+    ]
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 
 from caveclient.tools.testing import (
+    TEST_LOCAL_SERVER,
     CAVEclientMock,
     default_info,
     get_server_information,
     get_server_versions,
-    TEST_LOCAL_SERVER,
 )
 
 datastack_dict = get_server_information()

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -31,6 +31,7 @@ mapping = {
     "datastack_name": datastack_dict["datastack_name"],
 }
 info_url = url_template.format_map(mapping)
+info_version_url = endpoints.infoservice_endpoints_v2["get_version"].format_map(mapping)
 
 
 def test_global_client(global_client):  # noqa: F811
@@ -69,7 +70,13 @@ class TestFrameworkClient:
 
     @responses.activate
     def test_create_client(self):
-        responses.add(responses.GET, info_url, json=test_info, status=200)
+        responses.add(responses.GET, url=info_url, json=test_info, status=200)
+        responses.add(
+            responses.GET,
+            url=info_version_url,
+            json=str(server_versions["info_server_version"]),
+            status=200,
+        )
         _ = CAVEclient(
             datastack_dict["datastack_name"],
             server_address=datastack_dict["global_server"],
@@ -79,6 +86,12 @@ class TestFrameworkClient:
     @responses.activate
     def test_create_versioned_client(self):
         responses.add(responses.GET, info_url, json=test_info, status=200)
+        responses.add(
+            responses.GET,
+            url=info_version_url,
+            json=str(server_versions["info_server_version"]),
+            status=200,
+        )
 
         endpoint_mapping = self.default_mapping
         endpoint_mapping["emas_server_address"] = datastack_dict["global_server"]
@@ -160,6 +173,12 @@ class TestFrameworkClient:
     @responses.activate
     def test_set_session_defaults(self):
         responses.add(responses.GET, info_url, json=test_info, status=200)
+        responses.add(
+            responses.GET,
+            url=info_version_url,
+            json=str(server_versions["info_server_version"]),
+            status=200,
+        )
 
         pool_maxsize = 21
         pool_block = True

--- a/tests/test_infoservice.py
+++ b/tests/test_infoservice.py
@@ -4,7 +4,7 @@ from responses import matchers
 
 from caveclient.endpoints import infoservice_endpoints_v2
 
-from .conftest import datastack_dict, test_info, mirror_info, image_mirrors
+from .conftest import datastack_dict, image_mirrors, mirror_info, test_info
 
 
 def test_info_d(myclient):

--- a/tests/test_skeletons.py
+++ b/tests/test_skeletons.py
@@ -17,6 +17,7 @@ from .conftest import (
     mat_apiv2_specified_client,  # noqa: F401
     test_info,
     version_specified_client,  # noqa: F401
+    server_versions,
 )
 
 sk_mapping = {
@@ -42,6 +43,9 @@ info_mapping = {
 }
 url_template = endpoints.infoservice_endpoints_v2["datastack_info"]
 info_url = url_template.format_map(info_mapping)
+info_version_url = endpoints.infoservice_endpoints_v2["get_version"].format_map(
+    info_mapping
+)
 
 
 class TestSkeletonsClient:
@@ -49,6 +53,13 @@ class TestSkeletonsClient:
 
     @responses.activate
     def test_create_client(self):
+        responses.add(
+            responses.GET,
+            url=info_version_url,
+            json=str(server_versions["info_server_version"]),
+            status=200,
+        )
+
         responses.add(responses.GET, url=info_url, json=test_info, status=200)
         _ = CAVEclient(
             datastack_dict["datastack_name"],

--- a/tests/test_skeletons.py
+++ b/tests/test_skeletons.py
@@ -15,9 +15,9 @@ from .conftest import (
     datastack_dict,
     global_client,  # noqa: F401
     mat_apiv2_specified_client,  # noqa: F401
+    server_versions,
     test_info,
     version_specified_client,  # noqa: F401
-    server_versions,
 )
 
 sk_mapping = {


### PR DESCRIPTION
Following recent changes to the info service, I'm adding `image_mirror` as an optional parameter on a number of info service calls. This will allow different sources of imagery to be incorporated naturally in the info service.

* New functions `get_image_mirrors` and `get_image_mirror_names` that show the full info or just the unique name of each mirror for an aligned volume.
* New parameters `image_mirror` in `get_aligned_volume_info`, `get_datastack_info`, `image_cloudvolume`, and `image_source` to select the correct source.
* Adding the new version endpoint to the info service to use these
* Fixed a bug across all clients where `self.default_endpoint_mapping` was changing if any of its keys were changed on the fly in a function. Most importantly, if you specified a different datastack than the "main" one for the client, that value would persist across future calls.
* Added tests and updated CAVEclientMock to have the Info service version. 

This is currently treated as a draft because the info service feature is not yet released and deployed.

I have a very small concern remaining. The main thing I'm not sure about with this current implementation is that I'm not caching all of these mirrors. I don't imagine they will be used again and again, because presumably one just picks a mirror and goes with it. The regular info dictionary with the specified image mirror _is_ cached, so that seems like the more important thing.