### PR TITLE
Onboarding function

### DIFF
--- a/caveclient/__main__.py
+++ b/caveclient/__main__.py
@@ -1,5 +1,5 @@
-import sys
 import argparse
+
 from caveclient.frameworkclient import CAVEclient
 
 

--- a/caveclient/__main__.py
+++ b/caveclient/__main__.py
@@ -1,0 +1,43 @@
+import sys
+import argparse
+from caveclient.frameworkclient import CAVEclient
+
+
+def main():
+    """Main entry point for the CAVEclient CLI."""
+    parser = argparse.ArgumentParser(description="CAVEclient command-line interface")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Setup token command
+    setup_parser = subparsers.add_parser(
+        "setup-token", help="Set up authentication token"
+    )
+    setup_parser.add_argument(
+        "server_address", help="Server address for which to set up your token."
+    )
+    setup_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        default=True,
+        help="Overwrite existing token",
+    )
+    setup_parser.add_argument(
+        "--no-open",
+        action="store_false",
+        dest="open",
+        default=True,
+        help="Do not open browser for token setup",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "setup-token":
+        CAVEclient.setup_token(
+            server_address=args.server_address, overwrite=args.overwrite, open=args.open
+        )
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -52,6 +52,8 @@ def write_token(token, filepath, key, overwrite=True, ignore_readonly=False):
 
 
 def server_token_filename(server_address):
+    if urllib.parse.urlparse(server_address).scheme == "":
+        server_address = "https://" + server_address
     server = urllib.parse.urlparse(server_address).netloc
     server_file = server + "-cave-secret.json"
     server_file_path = os.path.join(default_token_location, server_file)
@@ -171,7 +173,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         if make_new:
             return self.get_new_token(open=open)
 
-        auth_url = auth_endpoints_v1["get_tokens"].format_map(
+        auth_url = auth_endpoints_v1["user_tokens_page"].format_map(
             self._default_endpoint_mapping
         )
         txt = f"""Tokens need to be acquired by hand. Please follow the following steps:
@@ -187,6 +189,21 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         if open:
             webbrowser.open(auth_url)
         return None
+
+    def get_token_page(self, open=True) -> str:
+        """Open the token page in a web browser.
+
+        Parameters
+        ----------
+        open : bool, optional
+            If True, opens a web browser to the web page where you can retrieve a token.
+        """
+        auth_url = auth_endpoints_v1["user_tokens_page"].format_map(
+            self._default_endpoint_mapping
+        )
+        if open:
+            webbrowser.open(auth_url)
+        return auth_url
 
     def get_tokens(self):
         """Get the tokens setup for this users
@@ -281,7 +298,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
 
         if save_token_file is None:
             raise ValueError("No token file is set")
-        if write_to_server_file:
+        if write_to_server_file and len(self._server_file_path) > 0:
             write_token(
                 token,
                 self._server_file_path,

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -48,19 +48,21 @@ def write_map(data, filename=None):
             json.dump(data, f)
         return True
     else:
-        logging.warn(
+        logging.debug(
             f"Did not write cache — file {os.path.expanduser(filename)} is not writeable"
         )
         return False
 
 
-def handle_server_address(datastack, server_address, filename=None, write=False):
+def handle_server_address(
+    datastack, server_address, filename=None, write=False, do_log=True
+):
     data = read_map(filename)
     if server_address is not None and datastack is not None:
         if write and server_address != data.get(datastack):
             data[datastack] = server_address
             wrote = write_map(data, filename)
-            if wrote:
+            if wrote and do_log:
                 logger.warning(
                     f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datastack '{datastack}'"
                 )

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -261,6 +261,7 @@ auth_endpoints_v1 = {
     "get_tokens": v1_auth + "/user/token",
     "get_users": v1_auth + "/user",
     "get_group_users": v1_auth + "/group/{group_id}/user",
+    "user_tokens_page": "{auth_server_address}" + "/sticky_auth/settings/tokens",
 }
 
 auth_api_versions = {

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-import re
-from typing import Optional
 import getpass
+import re
+from datetime import datetime
+from typing import Optional
 
 from .annotationengine import AnnotationClient
 from .auth import AuthClient, default_token_file

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -187,10 +187,9 @@ class CAVEclient(object):
             print("No datastacks found. Setup complete!")
             return
         else:
-            print(f"Found datastacks:\n{''.join(datastack_name_list)}")
             while True:
                 setup_all = input(
-                    "Configure all datastacks to use this server automatically ('Y', recommended), specify individual datastacks ('n'), or finish now ('exit'). (Y/n/exit) "
+                    "Set all of your datastacks to use this token and server ('Y', recommended), specify individual datastacks ('n'), or finish now ('exit'). (Y/n/exit) "
                 )
                 if setup_all.lower() in ["y", "yes", ""]:
                     for ds in datastack_names:
@@ -204,6 +203,7 @@ class CAVEclient(object):
                     print(complete_message)
                     return
                 elif setup_all.lower() in ["n", "no"]:
+                    print(f"Found datastacks:\n{''.join(datastack_name_list)}")
                     while True:
                         datastack_name = input(
                             "Enter the name of a datastack to use this server automatically or 'exit' to finish: "

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+import re
 from typing import Optional
+import getpass
 
 from .annotationengine import AnnotationClient
 from .auth import AuthClient, default_token_file
@@ -128,6 +130,97 @@ class CAVEclient(object):
                 info_cache=info_cache,
                 version=version,
             )
+
+    @staticmethod
+    def setup_token(
+        server_address: str,
+        overwrite: bool = True,
+        open: bool = True,
+    ):
+        """Set up a new or existing user token for a CAVE server.
+
+        Parameters
+        ----------
+        server_address : str
+            The server address to set up the token for. This will be provided by your documentation or server administrator.
+        overwrite : bool, optional
+            If True, overwrite the existing token if it exists. If False, do not overwrite existing data.
+            Optional, defaults to True.
+        open : bool, optional
+            If True, open the token page in a web browser to create or copy an existing token.
+            Optional, defaults to True.
+        """
+
+        global_client = CAVEclientGlobal(server_address=server_address)
+        page_url = global_client.auth.get_token_page(open=open)
+        print(f"Visit {page_url} and copy an existing token or create a new one.")
+        while True:
+            new_token = getpass.getpass(
+                "Paste your auth token (input will be hidden): "
+            )
+            new_token = new_token.strip().lower()
+            if re.match(r"^[a-f0-9]{32}$", new_token):
+                break
+            else:
+                print(
+                    "Invalid token format. Please ensure it is a 32-character alphanumeric string."
+                )
+        global_client.auth.save_token(token=new_token.strip(), overwrite=overwrite)
+
+        complete_message = "You will not need to specify a server address when initializing a client for configured datastacks in the future.\nSetup complete!"
+
+        client = CAVEclientGlobal(server_address=server_address)
+        datastack_names = sorted(client.info.get_datastacks())
+        datastack_name_list = [f"\t{ds}\n" for ds in datastack_names]
+        if len(datastack_names) == 0:
+            print("No datastacks found. Setup complete!")
+            return
+        else:
+            print(f"Found datastacks:\n{''.join(datastack_name_list)}")
+            while True:
+                setup_all = input(
+                    "Configure all datastacks to use this server automatically ('Y', recommended), specify individual datastacks ('n'), or finish now ('exit'). (Y/n/exit) "
+                )
+                if setup_all.lower() in ["y", "yes", ""]:
+                    for ds in datastack_names:
+                        _set_up_token(
+                            client,
+                            token=new_token,
+                            datastack_name=ds,
+                            overwrite=overwrite,
+                        )
+                    print("All datastacks are configured to use this server address.")
+                    print(complete_message)
+                    return
+                elif setup_all.lower() in ["n", "no"]:
+                    while True:
+                        datastack_name = input(
+                            "Enter the name of a datastack to use this server automatically or 'exit' to finish: "
+                        )
+                        if datastack_name.lower() == "exit":
+                            break
+                        else:
+                            ds = datastack_name.strip()
+                            if ds not in datastack_names:
+                                print(f"Datastack '{ds}' not found.")
+                                continue
+                            else:
+                                _set_up_token(
+                                    client,
+                                    token=new_token,
+                                    datastack_name=ds,
+                                    overwrite=overwrite,
+                                )
+                                print(f"Token set up for datastack: {datastack_name}.")
+                    print(complete_message)
+                    return
+                elif setup_all.lower() in ["exit"]:
+                    print(
+                        f"Finished setting up token for {server_address} with no datasets configured."
+                    )
+                    return
+                else:
+                    print("Invalid input. Please try again.")
 
 
 class CAVEclientGlobal(object):
@@ -598,3 +691,30 @@ class CAVEclientFull(CAVEclientGlobal):
 
     def __repr__(self):
         return f"CAVEclient<datastack_name={self.datastack_name}, server_address={self.server_address}>"
+
+
+def _set_up_token(
+    client: CAVEclientGlobal,
+    token: str,
+    datastack_name: str,
+    overwrite: bool,
+):
+    local_server = client.info.get_datastack_info(datastack_name).get("local_server")
+    handle_server_address(
+        datastack=datastack_name,
+        server_address=client.server_address,
+        write=True,
+        do_log=False,
+    )
+    if local_server:
+        client._auth._local_server = local_server
+        try:
+            client.auth.save_token(
+                token=token,
+                overwrite=overwrite,
+                local_server=True,
+                ignore_readonly=True,
+            )
+        except ValueError as e:
+            print(f"Could not save token for {datastack_name}: {e}")
+    pass

--- a/caveclient/jsonservice.py
+++ b/caveclient/jsonservice.py
@@ -382,6 +382,7 @@ class JSONService(ClientBase):
             raise ValueError(target_site_error)
 
         if format_properties:
+            auth_text = "middleauth+"  # Only used in spelunker context anyway.
             url_mapping = self.default_url_mapping
             url_mapping["state_id"] = state_id
             get_state_url = self._endpoints["get_properties"][:-5].format_map(

--- a/caveclient/tools/testing.py
+++ b/caveclient/tools/testing.py
@@ -25,6 +25,7 @@ DEFAULT_INFO_SERVER_VERSION = "999.0.0"
 
 TEST_GLOBAL_SERVER = os.environ.get("TEST_SERVER", "https://test.cave.com")
 TEST_LOCAL_SERVER = os.environ.get("TEST_LOCAL_SERVER", "https://local.cave.com")
+TEST_IMAGE_SERVER = os.environ.get("TEST_IMAGE_SERVER", "gs://my-test-bucket/images")
 TEST_DATASTACK = os.environ.get("TEST_DATASTACK", "test_stack")
 DEFAULT_MATERIALIZATION_VERSONS = [1, 2]
 
@@ -155,6 +156,7 @@ def get_api_versions(
 
 def default_info(
     local_server: str = TEST_LOCAL_SERVER,
+    image_source: str = TEST_IMAGE_SERVER,
 ) -> dict:
     """Generate a info service info file for testing
 
@@ -172,15 +174,15 @@ def default_info(
         "viewer_site": "http://neuromancer-seung-import.appspot.com/",
         "aligned_volume": {
             "name": "test_volume",
-            "image_source": f"precomputed://https://{local_server}/test-em/v1",
+            "image_source": f"precomputed://{image_source}",
             "id": 1,
             "description": "This is a test only dataset.",
         },
         "synapse_table": "test_synapse_table",
         "description": "This is the first test datastack.",
         "local_server": local_server,
-        "segmentation_source": f"graphene://https://{local_server}/segmentation/table/test_v1",
-        "skeleton_source": f"precomputed://https://{local_server}/skeletoncache/api/v1/minnie65_phase3_v1/precomputed/skeleton/",
+        "segmentation_source": f"graphene://{local_server}/segmentation/table/test_v1",
+        "skeleton_source": f"precomputed://{local_server}/skeletoncache/api/v1/minnie65_phase3_v1/precomputed/skeleton/",
         "soma_table": "test_soma",
         "analysis_database": None,
         "viewer_resolution_x": 4.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ Repository = "https://github.com/CAVEconnectome/CAVEclient/"
 [project.optional-dependencies]
 cv = ["cloud-volume"]
 
+[project.scripts]
+caveclient = "caveclient.__main__:main"
+
 [dependency-groups]
 bump = ['bump-my-version']
 dev = [


### PR DESCRIPTION
Adding an onboarding method to CAVEclient and via a CLI.

```python
from caveclient import CAVEclient
CAVEclient.setup_token(server_address="https://global.daf-apis.com/") # No default here currently
```

or from a command line:
```bash
caveclient setup-token https://global.daf-apis.com
```

Will walk the user through getting a token from `https://global.daf-apis.com/sticky_auth/settings/tokens` (or equivalent, opens in a web browser by default), pasting it in (which will save it), and optionally (but recommended) setting up the datastack-to-server map for all data stacks that they see. An example is shown below:

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/380aff28-22a6-47f1-bb89-2e0b3d4e779a" />
