### PR TITLE
refactor datastack-to-server cache

### DIFF
--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -59,12 +59,13 @@ def handle_server_address(
 ):
     data = read_map(filename)
     if server_address is not None and datastack is not None:
-        if write and server_address != data.get(datastack):
+        old_address = data.get(datastack)
+        if server_address != old_address and write:
             data[datastack] = server_address
             wrote = write_map(data, filename)
             if wrote and do_log:
                 logger.warning(
-                    f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datastack '{datastack}'"
+                    f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datastack '{datastack}'; previously '{old_address}'"
                 )
         return server_address
     else:

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -22,21 +22,16 @@ def read_map(filename=None):
 
 
 def is_writable(filename):
-    # File exists but is not writeable
-    if os.path.exists(os.path.expanduser(filename)):
-        if not os.access(os.path.expanduser(filename), os.W_OK):
-            return False
-    else:
-        try:
-            # File does not exist so make the directories if possible
-            if not os.path.exists(os.path.expanduser(DEFAULT_LOCATION)):
-                os.makedirs(os.path.expanduser(DEFAULT_LOCATION))
-            with open(os.path.expanduser(filename), "w") as f:
-                if not f.writable():
-                    return False
-        except IOError:
-            return False
-    return True
+    path = os.path.expanduser(filename)
+    if os.path.exists(path):
+        return os.access(path, os.W_OK)
+    parent = os.path.dirname(path) or os.path.expanduser(DEFAULT_LOCATION)
+    try:
+        if not os.path.exists(parent):
+            os.makedirs(parent)
+    except OSError:
+        return False
+    return os.access(parent, os.W_OK)
 
 
 def write_map(data, filename=None):

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -1,4 +1,6 @@
 import getpass
+import logging
+import os
 import re
 from datetime import datetime
 from typing import Optional
@@ -8,7 +10,12 @@ from requests.exceptions import HTTPError
 from .annotationengine import AnnotationClient
 from .auth import AuthClient, default_token_file
 from .chunkedgraph import ChunkedGraphClient
-from .datastack_lookup import handle_server_address
+from .datastack_lookup import (
+    DEFAULT_DATASTACK_FILE,
+    DEFAULT_LOCATION,
+    handle_server_address,
+    is_writable,
+)
 from .emannotationschemas import SchemaClient
 from .endpoints import default_global_server_address
 from .infoservice import InfoServiceClient
@@ -16,6 +23,8 @@ from .jsonservice import JSONService
 from .l2cache import L2CacheClient
 from .materializationengine import MaterializationClient
 from .skeletonservice import SkeletonClient
+
+logger = logging.getLogger(__name__)
 
 
 class GlobalClientError(Exception):
@@ -511,6 +520,11 @@ class CAVEclientFull(CAVEclientGlobal):
         [get_session_defaults](../extended_api/session_config.md/#caveclient.session_config.get_session_defaults)
         """
 
+        if write_server_cache and not is_writable(
+            os.path.join(DEFAULT_LOCATION, DEFAULT_DATASTACK_FILE)
+        ):
+            write_server_cache = False
+
         old_server_address = server_address
         server_address = handle_server_address(
             datastack_name,
@@ -541,20 +555,20 @@ class CAVEclientFull(CAVEclientGlobal):
         try:
             self.local_server = self.info.local_server()
         except HTTPError as e:
-            if e.response.status_code == 401 or e.response.status_code == 403:
-                msg = f"Access denied to datastack {datastack_name}!\nTo set up your token for server {server_address}, please run:\n\tCAVEclient.setup_token(server_address='{server_address}')\nand follow the instructions there."
-                print(msg)
-                raise e
-            else:
-                raise e
+            if e.response.status_code in (401, 403):
+                logger.warning(
+                    f"Access denied to datastack {datastack_name}. "
+                    f"To set up a token for server {server_address}, run "
+                    f"CAVEclient.setup_token(server_address='{server_address}')."
+                )
+            raise
         self.auth.local_server = self.local_server
 
-        # If it worked, actually try to write version.
         if write_server_cache:
             handle_server_address(
                 datastack=datastack_name,
                 server_address=old_server_address,
-                write=write_server_cache,
+                write=True,
                 do_log=True,
             )
 


### PR DESCRIPTION
Updated the datastack-to-server cache writing logic to only overwrite a datastack's value once a login was successful and to advertise the `setup_token` function if it was not successful.