### PR TITLE
Correct multiline string syntax causing unintended whitespace in warning

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -48,8 +48,8 @@ def deserialize_query_response(response):
             return pa.deserialize(response.content)
         except NameError:
             (
-                "Deserialization of this request requires an older version of Pyarrow (version 3 works).\
-                Update Materialization Deployment or locally downgrade Pyarrow."
+                "Deserialization of this request requires an older version of Pyarrow (version 3 works)."
+                " Update Materialization Deployment or locally downgrade Pyarrow."
             )
     else:
         raise ValueError(
@@ -2067,8 +2067,8 @@ class MaterializationClient(ClientBase):
         >>>     }
         """
         logging.warning(
-            "Deprecation: this method is to facilitate beta testing of this feature, \
-            it will likely get removed in future versions. "
+            "Deprecation: this method is to facilitate beta testing of this feature,"
+            " it will likely get removed in future versions. "
         )
         timestamp = convert_timestamp(timestamp)
         return_df = True


### PR DESCRIPTION
Previously live_live_queries would cause this warning to print:

    WARNING:root:Deprecation: this method is to facilitate beta testing of this feature,             it will likely get removed in future versions.

which appears to accidentally have a block of whitespace in it. I removed it by correcting what looks like an incorrect multiline string syntax. (Since the string is within parentheses, no escape is needed at the end of the first line. Even if an escape were needed, it would need to come after a `"` that closes the first line's string.)

Now we get the correct

    WARNING:root:Deprecation: this method is to facilitate beta testing of this feature, it will likely get removed in future versions. 