### PR TITLE
Add arrow type to baseencoder class

### DIFF
--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class BaseEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, (np.ndarray, pd.Series, pd.Index)):
+        if isinstance(obj, (np.ndarray, pd.Series, pd.Index, pd.arrays.ArrowExtensionArray)):
             return obj.tolist()
         if isinstance(obj, set):
             return list(obj)


### PR DESCRIPTION
In the new Arrow-backed dataframes, df['column'].values is now an ArrowExtensionArray. This needs to be added to the BaseEncoder class for JSON serialization.